### PR TITLE
Feature: Custom language detectors

### DIFF
--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -21,6 +21,8 @@ export default {
     format: (value, format) => (format === 'uppercase' ? value.toUpperCase() : value),
   },
   detection: {
+    serverDetectors: [],
+    browserDetectors: [],
     order: ['cookie', 'header', 'querystring'],
     caches: ['cookie'],
   },

--- a/src/create-i18next-client.js
+++ b/src/create-i18next-client.js
@@ -1,21 +1,32 @@
 import isNode from 'detect-node'
 import i18next from 'i18next'
 import i18nextXHRBackend from 'i18next-xhr-backend'
-import i18nextBrowserLanguageDetector from 'i18next-browser-languagedetector'
+import I18nextBrowserLanguageDetector from 'i18next-browser-languagedetector'
 
 const i18n = i18next.default ? i18next.default : i18next
 i18n.nsFromReactTree = []
 
-if (isNode) {
-  const i18nextNodeBackend = eval("require('i18next-node-fs-backend')") // eslint-disable-line
-  const i18nextMiddleware = require('i18next-express-middleware')
-  i18n.use(i18nextNodeBackend).use(i18nextMiddleware.LanguageDetector)
-} else {
-  i18n.use(i18nextXHRBackend).use(i18nextBrowserLanguageDetector)
-}
-
 export default (config) => {
   if (!i18n.isInitialized) {
+    if (isNode) {
+      const i18nextNodeBackend = eval("require('i18next-node-fs-backend')") // eslint-disable-line
+      const I18nextMiddleware = require('i18next-express-middleware')
+
+      const serverLanguageDetector = new I18nextMiddleware.LanguageDetector()
+
+      config.detection.serverDetectors.forEach((detector) => {
+        serverLanguageDetector.addDetector(detector)
+      })
+      i18n.use(i18nextNodeBackend).use(serverLanguageDetector)
+    } else {
+      const browserLanguageDetector = new I18nextBrowserLanguageDetector()
+
+      config.detection.browserDetectors.forEach((detector) => {
+        browserLanguageDetector.addDetector(detector)
+      })
+      i18n.use(i18nextXHRBackend).use(browserLanguageDetector)
+    }
+
     i18n.init(config)
   }
   return i18n


### PR DESCRIPTION
This is my proposal to support custom language detectors.

Would be nice if the interface for custom detectors wasn't different from each other

Currently we have

Server's interface:
```js
 lookup(req, res, options)
```

Client's interface:
```js
lookup(options)
```

Which make it unpractical to write isomorphic detectors, changing to the interface below would make things much simpler since we wouldn't need to write two detectors
```js
lookup(options, req, res)
```

