### PR TITLE
bugfix: remove deconstruction for pageProps

### DIFF
--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -63,7 +63,7 @@ export default function (WrappedComponent) {
       return {
         initialI18nStore,
         initialLanguage,
-        ...pageProps,
+        pageProps,
       }
     }
 


### PR DESCRIPTION
`getInitialProps` in Page will stop working if you deconstruction `pageProps`.