### PR TITLE
Feature: Enable default language subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ myapp.com/de/
 myapp.com/es/
 ```
 
+If you want to enable default locale subpath, pass this option into the `NextI18Next` constructor:
+```jsx
+new NextI18Next({ localeSubpaths: true, defaultLocaleSubpath: true })
+```
+
+And we will get:
+```
+myapp.com/en/
+myapp.com/fr/
+myapp.com/de/
+myapp.com/es/
+```
+
 The main "gotcha" with locale subpaths is routing. We want to be able to route to "naked" routes, and not have to worry about the locale subpath part of the route:
 
 ```jsx
@@ -129,14 +142,15 @@ class SomeLink extends React.Component {
 
 ## Options
 
-| Key  | Default value |
-| ------------- | ------------- |
-| `defaultLanguage`  | `"en"`  |
-| `otherLanguages` | `[]`  |
-| `localePath` | `'static/locales'`  |
-| `localeStructure` | `'{{lng}}/{{ns}}'`  |
-| `localeSubpaths` | `false`  |
-| `defaultNS` | `'common'`  |
+| Key                    | Default value      |
+| ---------------------- | ------------------ |
+| `defaultLanguage`      | `"en"`             |
+| `otherLanguages`       | `[]`               |
+| `localePath`           | `'static/locales'` |
+| `localeStructure`      | `'{{lng}}/{{ns}}'` |
+| `localeSubpaths`       | `false`            |
+| `defaultLocaleSubpath` | `false`            |
+| `defaultNS`            | `'common'`         |
 
 ## Notes
 

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -32,7 +32,7 @@ export default function () {
       if (Array.isArray(i18n.languages) && i18n.languages.length > 0) {
         [lng] = i18n.languages
       }
-      if (localeSubpaths && lng && lng !== (defaultLanguage || defaultLocaleSubpath)) {
+      if (localeSubpaths && lng && (lng !== defaultLanguage || defaultLocaleSubpath)) {
         const url = new Url(href, true)
         url.set('query', { ...url.query, lng })
 

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -21,18 +21,17 @@ import PropTypes from 'prop-types'
 import NextLink from 'next/link'
 
 export default function () {
-
   const { config, i18n } = this
 
   class Link extends React.Component {
     render() {
-      const { defaultLanguage, localeSubpaths } = config
+      const { defaultLanguage, localeSubpaths, defaultLocaleSubpath } = config
       const { children, href } = this.props
       let lng = null
       if (Array.isArray(i18n.languages) && i18n.languages.length > 0) {
         [lng] = i18n.languages
       }
-      if (localeSubpaths && lng && lng !== defaultLanguage) {
+      if (localeSubpaths && lng && (lng !== defaultLanguage || defaultLocaleSubpath)) {
         return (
           <NextLink href={`${href}?lng=${lng}`} as={`/${lng}${href}`}>
             {children}
@@ -53,5 +52,4 @@ export default function () {
     force `Link` to rerender on language change
   */
   return this.withNamespaces()(Link)
-
 }

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -4,6 +4,7 @@ const DEFAULT_NAMESPACE = 'common'
 const LOCALE_PATH = 'static/locales'
 const LOCALE_STRUCTURE = '{{lng}}/{{ns}}'
 const LOCALE_SUBPATHS = false
+const DEFAULT_LOCALE_SUBPATH = false
 
 export default {
   defaultLanguage: DEFAULT_LANGUAGE,
@@ -13,6 +14,7 @@ export default {
   localePath: LOCALE_PATH,
   localeStructure: LOCALE_STRUCTURE,
   localeSubpaths: LOCALE_SUBPATHS,
+  defaultLocaleSubpath: DEFAULT_LOCALE_SUBPATH,
   ns: [DEFAULT_NAMESPACE],
   defaultNS: DEFAULT_NAMESPACE,
   interpolation: {

--- a/src/utils/lng-path-corrector.js
+++ b/src/utils/lng-path-corrector.js
@@ -1,6 +1,5 @@
 export default (config, i18n, currentRoute, currentLanguage = i18n.languages[0]) => {
-
-  const { defaultLanguage, allLanguages } = config
+  const { defaultLanguage, allLanguages, defaultLocaleSubpath } = config
 
   if (!allLanguages.includes(currentLanguage)) {
     return currentRoute
@@ -16,7 +15,7 @@ export default (config, i18n, currentRoute, currentLanguage = i18n.languages[0])
     }
   }
 
-  if (currentLanguage !== defaultLanguage) {
+  if (currentLanguage !== defaultLanguage || defaultLocaleSubpath) {
     as = `/${currentLanguage}${href}`
     href += `?lng=${currentLanguage}`
   } else {

--- a/src/utils/lng-path-detector.js
+++ b/src/utils/lng-path-detector.js
@@ -22,8 +22,8 @@ export default (req, res, next) => {
       req.i18n.changeLanguage(defaultLanguage)
     }
     /*
-      If a user has a default language prefix
-      in their URL, strip it. Except it has defaultLocaleSubpath to true
+      If a user has a default language prefix in their URL
+      and defaultLocaleSubpath set to false, strip it.
     */
     if (
       language === defaultLanguage

--- a/src/utils/lng-path-detector.js
+++ b/src/utils/lng-path-detector.js
@@ -1,7 +1,7 @@
 export default (req, res, next) => {
   if (req.i18n) {
     const language = req.i18n.languages[0]
-    const { allLanguages, defaultLanguage } = req.i18n.options
+    const { allLanguages, defaultLanguage, defaultLocaleSubpath } = req.i18n.options
     /*
       If a user has hit a subpath which does not
       match their language, give preference to
@@ -23,9 +23,13 @@ export default (req, res, next) => {
     }
     /*
       If a user has a default language prefix
-      in their URL, strip it.
+      in their URL, strip it. Except it has defaultLocaleSubpath to true
     */
-    if (language === defaultLanguage && req.url.startsWith(`/${defaultLanguage}/`)) {
+    if (
+      language === defaultLanguage
+      && req.url.startsWith(`/${defaultLanguage}/`)
+      && !defaultLocaleSubpath
+    ) {
       res.redirect(301, req.url.replace(`/${defaultLanguage}/`, '/'))
     }
   }

--- a/src/utils/lng-path-detector.js
+++ b/src/utils/lng-path-detector.js
@@ -1,7 +1,9 @@
 export default (req, res, next) => {
   if (req.i18n) {
     const language = req.i18n.languages[0]
-    const { allLanguages, defaultLanguage, defaultLocaleSubpath } = req.i18n.options
+    const {
+      allLanguages, defaultLanguage, localeSubpaths, defaultLocaleSubpath,
+    } = req.i18n.options
     /*
       If a user has hit a subpath which does not
       match their language, give preference to
@@ -21,14 +23,22 @@ export default (req, res, next) => {
     if (language !== defaultLanguage && !req.url.startsWith(`/${language}/`)) {
       req.i18n.changeLanguage(defaultLanguage)
     }
+
+    /*
+      If a user enable the localeSubpaths and defaultLocaleSubpath,
+      request to the root path will redirect to default language
+     */
+    if (localeSubpaths && defaultLocaleSubpath && req.url === '/') {
+      res.redirect(301, req.url.replace('/', `/${defaultLanguage}/`))
+    }
     /*
       If a user has a default language prefix in their URL
       and defaultLocaleSubpath set to false, strip it.
     */
     if (
-      language === defaultLanguage
+      !defaultLocaleSubpath
+      && language === defaultLanguage
       && req.url.startsWith(`/${defaultLanguage}/`)
-      && !defaultLocaleSubpath
     ) {
       res.redirect(301, req.url.replace(`/${defaultLanguage}/`, '/'))
     }


### PR DESCRIPTION
This is my proposal to enable default language subpath.

Currently the default language just showing the root path `/`, and we might want to show the language `/en/` in the address bar

To enable this feature by passing an option into the NextI18Next constructor:
```jsx
new NextI18Next({ localeSubpaths: true, defaultLocaleSubpath: true })
```

If `localeSubpaths` is false, the defaultLocaleSubpath won't work.