### PR TITLE
pass additional parameters of getInitialProps all the way down

### DIFF
--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -28,19 +28,19 @@ export default function (WrappedComponent) {
       }
     }
 
-    static async getInitialProps({ Component, ctx }) {
+    static async getInitialProps({ Component, ctx }, ...additionalContext) {
 
       let pageProps = {}
       let regularProps = {}
 
       if (Component.getInitialProps) {
-        pageProps = await Component.getInitialProps(ctx)
+        pageProps = await Component.getInitialProps(ctx, ...additionalContext)
       }
 
       // Run getInitialProps on wrapped _app
       if (WrappedComponent.getInitialProps) {
         const { pageProps: wrappedPageProps, ...rest } = await WrappedComponent
-          .getInitialProps({ Component, ctx })
+          .getInitialProps({ Component, ctx }, ...additionalContext)
         pageProps = {
           ...pageProps,
           ...wrappedPageProps,


### PR DESCRIPTION
Hey guys,

when using this package I stumbled upon the problem, that the next-apollo integration provides the apollo client object as second parameter to the getInitialProps call. But as the HOC for the NextApp does not pass these values along that information is lost.

Use case is, that I need the apollo client in the getInitialProps of my app to fetch the authentication state of the user.

Maybe this is also helpful for others around here.

If this is anti-pattern or something you shouldn't do - please explain me why and what are possible options to work around that. I'm still pretty new to the whole nextjs ecosystem.

Thanks!