### PR TITLE
Add context to react-tree-walker call

### DIFF
--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -82,7 +82,7 @@ export default function (WrappedComponent) {
           if (instance && instance.props && instance.props.ns) {
             nsFromTree = [...new Set(nsFromTree.concat(instance.props.ns))]
           }
-        })
+        }, {})
       }
 
       // Step 3: Perform data fetching, depending on environment


### PR DESCRIPTION
By default react-tree-walker passes in an undefined context, which
breaks packages like Material UI and JSSProvider.  This fix passes
in an empty object for context, which fixes components that use the
legacy context API.

See 