### PR TITLE
Fix url.href in url-parse usage

### DIFF
--- a/__tests__/components/Link.test.js
+++ b/__tests__/components/Link.test.js
@@ -114,14 +114,14 @@ describe('Link component', () => {
     // without 'as' prop -- no query parameters
     let component = createLinkComponent()
 
-    expect(component.prop('href')).toEqual('http://localhost/foo/bar?lng=de')
+    expect(component.prop('href')).toEqual('/foo/bar?lng=de')
     expect(component.prop('as')).toEqual('/de/foo/bar')
 
     // without 'as' prop -- query parameters
     props.href = '/foo/bar?baz'
     component = createLinkComponent()
 
-    expect(component.prop('href')).toEqual('http://localhost/foo/bar?baz=&lng=de')
+    expect(component.prop('href')).toEqual('/foo/bar?baz&lng=de')
     expect(component.prop('as')).toEqual('/de/foo/bar?baz')
 
     props.href = '/foo/bar'
@@ -130,7 +130,7 @@ describe('Link component', () => {
     props.as = '/foo?bar'
     component = createLinkComponent()
 
-    expect(component.prop('href')).toEqual('http://localhost/foo/bar?lng=de')
+    expect(component.prop('href')).toEqual('/foo/bar?lng=de')
     expect(component.prop('as')).toEqual('/de/foo?bar')
   })
 })

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "react-i18next": "^8.4.0",
-    "url-parse": "^1.4.4"
+    "urijs": "^1.19.1"
   }
 }

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -19,7 +19,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
-import Url from 'url-parse'
+import URI from 'urijs'
 
 export default function () {
 
@@ -34,11 +34,15 @@ export default function () {
         [lng] = i18n.languages
       }
       if (localeSubpaths && lng && lng !== defaultLanguage) {
-        const url = new Url(href, true)
-        url.set('query', { ...url.query, lng })
+        const hrefWithLang = URI(href)
+          .addQuery('lng', lng)
+          .normalizeQuery()
+          .toString()
 
         return (
-          <NextLink href={url.href} as={`/${lng}${as || href}`}>{children}</NextLink>
+          <NextLink href={hrefWithLang} as={`/${lng}${as || href}`}>
+            {children}
+          </NextLink>
         )
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6308,11 +6308,6 @@ querystring@0.2.0, querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-querystringify@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
-  integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
-
 raf@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -6391,7 +6386,6 @@ react-i18next@^8.4.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-8.4.0.tgz#e9f0c5b9938b155eaa6051360614719c08cae72f"
   integrity sha512-zIO/bc1L0UUGdaws2y40cTiSQHuQud5e9SSodYM6MTzhJTI3iayxCCdgvotblOLM4taOD77Ct2/fUbheQIhyeg==
-
   dependencies:
     "@babel/runtime" "^7.1.2"
     create-react-context "0.2.3"
@@ -6679,11 +6673,6 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
-
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 reselect@^3.0.1:
   version "3.0.1"
@@ -7684,18 +7673,15 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+urijs@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.1.tgz#5b0ff530c0cbde8386f6342235ba5ca6e995d25a"
+  integrity sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-url-parse@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.4.tgz#cac1556e95faa0303691fec5cf9d5a1bc34648f8"
-  integrity sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==
-  dependencies:
-    querystringify "^2.0.0"
-    requires-port "^1.0.0"
 
 url@0.11.0, url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
In the current usage, if a URL without a protocol and host is passed
into URL, 'http://localhost' will be added to the beginning of the
href (e.g. '/foo' will become 'http://localhost/foo').  This change
ensures that a URL without a protocol and host is preserved and
left without the protocol and host (e.g. '/foo' remains '/foo').