### PR TITLE
Properly set namespace on client

### DIFF
--- a/__tests__/config/create-config-non-node.test.js
+++ b/__tests__/config/create-config-non-node.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { setUpTest, tearDownTest } from './test-helpers'
+import { userConfig, setUpTest, tearDownTest } from './test-helpers'
 
 import createConfig from '../../src/config/create-config'
 
@@ -46,6 +46,25 @@ describe('create configuration in non-production environment', () => {
     expect(config.preload).toBeUndefined()
 
     expect(config.ns).toEqual(['common'])
+
+    expect(config.backend.loadPath).toEqual('/static/locales/{{lng}}/{{ns}}.json')
+    expect(config.backend.addPath).toEqual('/static/locales/{{lng}}/{{ns}}.missing.json')
+  })
+
+  it('creates custom non-node non-production configuration', () => {
+    const config = createConfig(userConfig)
+
+    expect(config.defaultLanguage).toEqual('de')
+    expect(config.otherLanguages).toEqual(['fr', 'it'])
+    expect(config.fallbackLng).toEqual('it')
+    expect(config.load).toEqual('languageOnly')
+    expect(config.localePath).toEqual('static/translations')
+    expect(config.localeStructure).toEqual('{{ns}}/{{lng}}')
+    expect(config.localeSubpaths).toEqual(true)
+    expect(config.defaultNS).toEqual('universal')
+    expect(config.browserLanguageDetection).toEqual(false)
+
+    expect(config.ns).toEqual(['universal'])
 
     expect(config.backend.loadPath).toEqual('/static/locales/{{lng}}/{{ns}}.json')
     expect(config.backend.addPath).toEqual('/static/locales/{{lng}}/{{ns}}.missing.json')

--- a/__tests__/config/create-config.test.js
+++ b/__tests__/config/create-config.test.js
@@ -108,4 +108,25 @@ describe('create configuration in non-production environment', () => {
     expect(config.backend.loadPath).toEqual('/static/locales/{{lng}}/{{ns}}.json')
     expect(config.backend.addPath).toEqual('/static/locales/{{lng}}/{{ns}}.missing.json')
   })
+
+  it('creates custom client-side non-production configuration', () => {
+    process.browser = true
+    const config = createConfig(userConfig)
+
+    expect(config.defaultLanguage).toEqual('de')
+    expect(config.otherLanguages).toEqual(['fr', 'it'])
+    expect(config.fallbackLng).toEqual('it')
+    expect(config.load).toEqual('languageOnly')
+    expect(config.localePath).toEqual('static/translations')
+    expect(config.localeStructure).toEqual('{{ns}}/{{lng}}')
+    expect(config.localeSubpaths).toEqual(true)
+    expect(config.defaultNS).toEqual('universal')
+    expect(config.browserLanguageDetection).toEqual(false)
+
+    expect(config.ns).toEqual(['universal'])
+
+    expect(config.backend.loadPath).toEqual('/static/locales/{{lng}}/{{ns}}.json')
+    expect(config.backend.addPath).toEqual('/static/locales/{{lng}}/{{ns}}.missing.json')
+  })
+
 })

--- a/src/config/create-config.js
+++ b/src/config/create-config.js
@@ -10,6 +10,7 @@ export default (userConfig) => {
 
   combinedConfig.allLanguages = combinedConfig.otherLanguages
     .concat([combinedConfig.defaultLanguage])
+  combinedConfig.ns = [combinedConfig.defaultNS]
 
   if (isNode && !process.browser) {
     const fs = eval("require('fs')")


### PR DESCRIPTION
If a user specifies another defaultNS and we are client-side, then
config.ns will never be reassigned. This change properly sets the
ns key on the config object.

Resolves #64.