### PR TITLE
Catch configuration error in lngPathCorrector

### DIFF
--- a/__tests__/utils/lng-path-corrector.test.js
+++ b/__tests__/utils/lng-path-corrector.test.js
@@ -17,10 +17,11 @@ describe('lngPathCorrector utility function', () => {
     }
   })
 
-  it('returns current route if allLanguages does not include current language', () => {
+  it('throws if allLanguages does not include current language', () => {
     config.allLanguages = ['de', 'fr']
 
-    expect(lngPathCorrector(config, i18n, '/')).toEqual('/')
+    expect(() => lngPathCorrector(config, i18n, '/'))
+      .toThrowError('Invalid configuration: Current language is not included in all languages array')
   })
 
   it('strips off the default language', () => {

--- a/src/utils/lng-path-corrector.js
+++ b/src/utils/lng-path-corrector.js
@@ -3,7 +3,7 @@ export default (config, i18n, currentRoute, currentLanguage = i18n.languages[0])
   const { defaultLanguage, allLanguages } = config
 
   if (!allLanguages.includes(currentLanguage)) {
-    return currentRoute
+    throw new Error('Invalid configuration: Current language is not included in all languages array')
   }
 
   let href = currentRoute


### PR DESCRIPTION
If `currentLanguage` is not in the `config.allLanguages` array, throw an error.

Resolves #65.