### PR TITLE
Add createConsoleMessage functionality + logging configuration

### DIFF
--- a/__tests__/utils/console-message.test.js
+++ b/__tests__/utils/console-message.test.js
@@ -30,7 +30,7 @@ describe('createConsoleMessage utility function', () => {
   })
 
   it('Logs error messages', () => {
-    createConsoleMessage('err', 'Testing error message')
+    createConsoleMessage('error', 'Testing error message')
 
     expect(console.error).toHaveBeenCalledTimes(1)
   })

--- a/__tests__/utils/console-message.test.js
+++ b/__tests__/utils/console-message.test.js
@@ -68,13 +68,6 @@ describe('consoleMessage utility function', () => {
 
   })
 
-  it('Returns undefined if process.NODE_ENV !== test jest', () => {
-    process.env.NODE_ENV = 'test jest'
-    expect(consoleMessage('info', 'Testing test logging')).toBeUndefined()
-
-  })
-
-
   it('Returns undefined if strictMode is false', () => {
     process.env.NODE_ENV = 'production'
     expect(consoleMessage('info', 'Testing production logging', { strictMode: false })).toBeUndefined()

--- a/__tests__/utils/console-message.test.js
+++ b/__tests__/utils/console-message.test.js
@@ -4,7 +4,7 @@
 import { createConsoleMessage } from 'utils'
 
 
-describe('console-message info', () => {
+describe('createConsoleMessage utility function', () => {
   const OLD_ENV = process.env
 
   let consoleInfoSpy

--- a/__tests__/utils/console-message.test.js
+++ b/__tests__/utils/console-message.test.js
@@ -1,10 +1,16 @@
 /* eslint-disable no-console */
 /* eslint-env jest */
 
-import { createConsoleMessage } from 'utils'
+import { consoleMessage as _consoleMessage } from 'utils'
 
+const consoleMessage = _consoleMessage.bind({
+  config: {
+    strictMode: true,
+    errorStackTraceLimit: 0,
+  },
+})
 
-describe('createConsoleMessage utility function', () => {
+describe('consoleMessage utility function', () => {
   const OLD_ENV = process.env
 
   let consoleInfoSpy
@@ -30,25 +36,25 @@ describe('createConsoleMessage utility function', () => {
   })
 
   it('Logs error messages', () => {
-    createConsoleMessage('error', 'Testing error message')
+    consoleMessage('error', 'Testing error message')
 
     expect(console.error).toHaveBeenCalledTimes(1)
   })
 
   it('Logs info messages', () => {
-    createConsoleMessage('info', 'Testing info message')
+    consoleMessage('info', 'Testing info message')
 
     expect(console.info).toHaveBeenCalledTimes(1)
   })
 
   it('Logs warning messages', () => {
-    createConsoleMessage('warn', 'Testing warning message')
+    consoleMessage('warn', 'Testing warning message')
 
     expect(console.warn).toHaveBeenCalledTimes(1)
   })
 
   it('Logs info messages on all other type options', () => {
-    createConsoleMessage(undefined, 'Testing default info message')
+    consoleMessage(undefined, 'Testing default info message')
 
     expect(consoleInfoSpy).toHaveBeenCalledTimes(1)
     expect(consoleErrSpy).toHaveBeenCalledTimes(0)
@@ -58,26 +64,26 @@ describe('createConsoleMessage utility function', () => {
 
   it('Returns undefined if process.NODE_ENV === production', () => {
     process.env.NODE_ENV = 'production'
-    expect(createConsoleMessage('info', 'Testing production logging')).toBeUndefined()
+    expect(consoleMessage('info', 'Testing production logging')).toBeUndefined()
 
   })
 
   it('Returns undefined if process.NODE_ENV !== test jest', () => {
     process.env.NODE_ENV = 'test jest'
-    expect(createConsoleMessage('info', 'Testing test logging')).toBeUndefined()
+    expect(consoleMessage('info', 'Testing test logging')).toBeUndefined()
 
   })
 
 
   it('Returns undefined if strictMode is false', () => {
     process.env.NODE_ENV = 'production'
-    expect(createConsoleMessage('info', 'Testing production logging', { strictMode: false })).toBeUndefined()
+    expect(consoleMessage('info', 'Testing production logging', { strictMode: false })).toBeUndefined()
 
   })
 
   it('Return errors on non-string messages', () => {
-    expect(createConsoleMessage('info', { message: 'Message in object' })).toBeUndefined()
-    expect(createConsoleMessage('info', ['An', 'array', 'of', 'message'])).toBeUndefined()
-    expect(createConsoleMessage('info', () => 'Function message')).toBeUndefined()
+    expect(consoleMessage('info', { message: 'Message in object' })).toBeUndefined()
+    expect(consoleMessage('info', ['An', 'array', 'of', 'message'])).toBeUndefined()
+    expect(consoleMessage('info', () => 'Function message')).toBeUndefined()
   })
 })

--- a/__tests__/utils/console-message.test.js
+++ b/__tests__/utils/console-message.test.js
@@ -1,0 +1,83 @@
+/* eslint-disable no-console */
+/* eslint-env jest */
+
+import { createConsoleMessage } from 'utils'
+
+
+describe('console-message info', () => {
+  const OLD_ENV = process.env
+
+  let consoleInfoSpy
+  let consoleWarnSpy
+  let consoleErrSpy
+
+
+  beforeEach(() => {
+    consoleInfoSpy = jest.spyOn(console, 'info')
+    consoleWarnSpy = jest.spyOn(console, 'warn')
+    consoleErrSpy = jest.spyOn(console, 'error')
+
+    jest.resetModules() // this is important
+    process.env = { ...OLD_ENV }
+    delete process.env.NODE_ENV
+  })
+
+  afterEach(() => {
+    consoleErrSpy.mockRestore()
+    consoleInfoSpy.mockRestore()
+    consoleWarnSpy.mockRestore()
+    process.env = OLD_ENV
+  })
+
+  it('Logs error messages', () => {
+    createConsoleMessage('err', 'Testing error message')
+
+    expect(console.error).toHaveBeenCalledTimes(1)
+  })
+
+  it('Logs info messages', () => {
+    createConsoleMessage('info', 'Testing info message')
+
+    expect(console.info).toHaveBeenCalledTimes(1)
+  })
+
+  it('Logs warning messages', () => {
+    createConsoleMessage('warn', 'Testing warning message')
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('Logs info messages on all other type options', () => {
+    createConsoleMessage(undefined, 'Testing default info message')
+
+    expect(consoleInfoSpy).toHaveBeenCalledTimes(1)
+    expect(consoleErrSpy).toHaveBeenCalledTimes(0)
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(0)
+
+  })
+
+  it('Returns undefined if process.NODE_ENV === production', () => {
+    process.env.NODE_ENV = 'production'
+    expect(createConsoleMessage('info', 'Testing production logging')).toBeUndefined()
+
+  })
+
+  it('Returns undefined if process.NODE_ENV !== test jest', () => {
+    process.env.NODE_ENV = 'test jest'
+    expect(createConsoleMessage('info', 'Testing test logging')).toBeUndefined()
+
+  })
+
+
+  it('Returns undefined if strictMode is false', () => {
+    process.env.NODE_ENV = 'production'
+    expect(createConsoleMessage('info', 'Testing production logging', { strictMode: false })).toBeUndefined()
+
+  })
+
+  it('Return errors on non-string messages', () => {
+    expect(createConsoleMessage('info', { message: 'Message in object' })).toBeUndefined()
+    expect(createConsoleMessage('info', ['An', 'array', 'of', 'message'])).toBeUndefined()
+    expect(createConsoleMessage('info', () => 'Function message')).toBeUndefined()
+  })
+})

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1757,6 +1757,11 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -2360,6 +2365,21 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+css-select@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-what@2.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
+  integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
+
 cycle@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
@@ -2545,10 +2565,57 @@ doctrine@^2.0.2:
   dependencies:
     esutils "^2.0.2"
 
+dom-converter@~0.2:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
+  integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
+  dependencies:
+    utila "~0.4"
+
+dom-serializer@0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  integrity sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
+
+domelementtype@1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+  integrity sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=
+
+domhandler@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.1.0.tgz#d2646f5e57f6c3bab11cf6cb05d3c0acf7412594"
+  integrity sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=
+  dependencies:
+    domelementtype "1"
+
+domutils@1.1:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
+  integrity sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.6.1"
@@ -2630,6 +2697,11 @@ enhanced-resolve@^4.1.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.4.0"
     tapable "^1.0.0"
+
+entities@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 errno@^0.1.2, errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -3493,6 +3565,16 @@ htmlescape@1.1.1:
   resolved "https://registry.yarnpkg.com/htmlescape/-/htmlescape-1.1.1.tgz#3a03edc2214bca3b66424a3e7959349509cb0351"
   integrity sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=
 
+htmlparser2@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.3.0.tgz#cc70d05a59f6542e43f0e685c982e14c924a9efe"
+  integrity sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=
+  dependencies:
+    domelementtype "1"
+    domhandler "2.1"
+    domutils "1.1"
+    readable-stream "1.0"
+
 http-errors@1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
@@ -3886,6 +3968,11 @@ is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -4480,7 +4567,7 @@ neo-async@^2.5.0:
   integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
 
 next-i18next@../:
-  version "0.13.0"
+  version "0.16.0"
   dependencies:
     detect-node "^2.0.4"
     hoist-non-react-statics "^3.2.0"
@@ -4489,6 +4576,7 @@ next-i18next@../:
     i18next-express-middleware "^1.5.0"
     i18next-node-fs-backend "^2.1.0"
     i18next-xhr-backend "^1.5.1"
+    pretty-error "^2.1.1"
     prop-types "^15.6.2"
     react "^16.6.3"
     react-i18next "^8.4.0"
@@ -4672,6 +4760,13 @@ npmlog@^4.0.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+nth-check@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+  dependencies:
+    boolbase "~1.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -5005,6 +5100,14 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+pretty-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
+  integrity sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=
+  dependencies:
+    renderkid "^2.0.1"
+    utila "~0.4"
+
 pretty-time@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pretty-time/-/pretty-time-1.1.0.tgz#ffb7429afabb8535c346a34e41873adf3d74dd0e"
@@ -5272,6 +5375,16 @@ read-pkg@^2.0.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@1.0:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
@@ -5417,6 +5530,17 @@ regjsparser@^0.3.0:
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+
+renderkid@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.2.tgz#12d310f255360c07ad8fde253f6c9e9de372d2aa"
+  integrity sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==
+  dependencies:
+    css-select "^1.1.0"
+    dom-converter "~0.2"
+    htmlparser2 "~3.3.0"
+    strip-ansi "^3.0.0"
+    utila "^0.4.0"
 
 repeat-element@^1.1.2:
   version "1.1.2"
@@ -5975,6 +6099,11 @@ string_decoder@^1.0.0, string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
@@ -6407,6 +6536,11 @@ util@^0.10.3:
   integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
   dependencies:
     inherits "2.0.3"
+
+utila@^0.4.0, utila@~0.4:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
+  integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
 
 utils-merge@1.0.1:
   version "1.0.1"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.1.6",
     "@babel/node": "^7.0.0",
-    "@babel/plugin-transform-runtime": "^7.2.0",
+    "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "all-contributors-cli": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare": "yarn build",
     "run-example": "yarn build && cd example && rm -rf node_modules && yarn && yarn dev",
     "run-example:prod": "yarn build && cd example && rm -rf node_modules && yarn && yarn build && yarn start",
-    "test": "NODE_ENV=test jest",
+    "test": "NODE_ENV=test jest --silent",
     "contributors:check": "all-contributors check",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate"
@@ -41,7 +41,7 @@
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.1.6",
     "@babel/node": "^7.0.0",
-    "@babel/plugin-transform-runtime": "^7.1.0",
+    "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
     "all-contributors-cli": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "i18next-express-middleware": "^1.5.0",
     "i18next-node-fs-backend": "^2.1.0",
     "i18next-xhr-backend": "^1.5.1",
+    "pretty-error": "^2.1.1",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "react-i18next": "^8.4.0",

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -5,8 +5,6 @@ const LOCALE_PATH = 'static/locales'
 const LOCALE_STRUCTURE = '{{lng}}/{{ns}}'
 const LOCALE_SUBPATHS = false
 
-const NEXT_I18NEXT_TRACE_LIMIT = parseInt(`${process.env.NEXT_i18NEXT_TRACE_LIMIT}`, 10) || 0
-
 export default {
   defaultLanguage: DEFAULT_LANGUAGE,
   otherLanguages: OTHER_LANGUAGES,
@@ -37,5 +35,5 @@ export default {
     wait: true,
   },
   strictMode: true,
-  traceLimit: NEXT_I18NEXT_TRACE_LIMIT,
+  errorStackTraceLimit: parseInt(`${process.env.NEXT_i18NEXT_TRACE_LIMIT}`, 10) || 0,
 }

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -5,6 +5,8 @@ const LOCALE_PATH = 'static/locales'
 const LOCALE_STRUCTURE = '{{lng}}/{{ns}}'
 const LOCALE_SUBPATHS = false
 
+const NEXT_I18NEXT_TRACE_LIMIT = parseInt(`${process.env.NEXT_i18NEXT_TRACE_LIMIT}`, 10) || 0
+
 export default {
   defaultLanguage: DEFAULT_LANGUAGE,
   otherLanguages: OTHER_LANGUAGES,
@@ -34,4 +36,6 @@ export default {
   react: {
     wait: true,
   },
+  strictMode: true,
+  traceLimit: NEXT_I18NEXT_TRACE_LIMIT,
 }

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -35,5 +35,5 @@ export default {
     wait: true,
   },
   strictMode: true,
-  errorStackTraceLimit: parseInt(`${process.env.NEXT_i18NEXT_TRACE_LIMIT}`, 10) || 0,
+  errorStackTraceLimit: 0,
 }

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -2,12 +2,10 @@ import React from 'react'
 import Router from 'next/router'
 
 import { I18nextProvider } from 'react-i18next'
-import { lngPathCorrector } from 'utils'
+import { createConsoleMessage, lngPathCorrector } from 'utils'
 import { NextStaticProvider } from 'components'
 
 import hoistNonReactStatics from 'hoist-non-react-statics'
-import createConsoleMessage from '../utils/console-message'
-
 
 export default function (WrappedComponent) {
 

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -26,7 +26,19 @@ export default function (WrappedComponent) {
               Router.replace(href, as, { shallow: true })
             }
           }
+
         })
+      }
+
+      this.createConsoleMessage = (type, message, traceLimit = 0) => {
+        createConsoleMessage(
+          type,
+          message,
+          {
+            strictMode: config.strictMode,
+            traceLimit,
+          },
+        )
       }
     }
 
@@ -73,7 +85,10 @@ export default function (WrappedComponent) {
       if (Array.isArray(pageProps.namespacesRequired)) {
         ({ namespacesRequired } = pageProps)
       } else if (process.env.NODE_ENV !== 'production') {
-        createConsoleMessage('warn', `You have not declared a namespacesRequired array on your page-level component: ${Component.displayName}. This will cause all namespaces to be sent down to the client, possibly negatively impacting the performance of your app. For more info, see: https://github.com/isaachinman/next-i18next#4-declaring-namespace-dependencies`)
+        this.createConsoleMessage(
+          'warn',
+          `You have not declared a namespacesRequired array on your page-level component: ${Component.displayName}. This will cause all namespaces to be sent down to the client, possibly negatively impacting the performance of your app. For more info, see: https://github.com/isaachinman/next-i18next#4-declaring-namespace-dependencies`,
+        )
       }
 
       // We must always send down the defaultNS, otherwise

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -6,6 +6,8 @@ import { lngPathCorrector } from 'utils'
 import { NextStaticProvider } from 'components'
 
 import hoistNonReactStatics from 'hoist-non-react-statics'
+import createConsoleMessage from '../utils/console-message'
+
 
 export default function (WrappedComponent) {
 
@@ -71,7 +73,7 @@ export default function (WrappedComponent) {
       if (Array.isArray(pageProps.namespacesRequired)) {
         ({ namespacesRequired } = pageProps)
       } else if (process.env.NODE_ENV !== 'production') {
-        console.warn(`You have not declared a namespacesRequired array on your page-level component: ${Component.displayName}. This will cause all namespaces to be sent down to the client, possibly negatively impacting the performance of your app. For more info, see: https://github.com/isaachinman/next-i18next#4-declaring-namespace-dependencies`)
+        createConsoleMessage('warn', `You have not declared a namespacesRequired array on your page-level component: ${Component.displayName}. This will cause all namespaces to be sent down to the client, possibly negatively impacting the performance of your app. For more info, see: https://github.com/isaachinman/next-i18next#4-declaring-namespace-dependencies`)
       }
 
       // We must always send down the defaultNS, otherwise

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -2,27 +2,16 @@ import React from 'react'
 import Router from 'next/router'
 
 import { I18nextProvider } from 'react-i18next'
-import { createConsoleMessage, lngPathCorrector } from 'utils'
+import { lngPathCorrector } from 'utils'
 import { NextStaticProvider } from 'components'
 
 import hoistNonReactStatics from 'hoist-non-react-statics'
 
 export default function (WrappedComponent) {
 
-  const { config, i18n } = this
+  const { config, consoleMessage, i18n } = this
 
   class AppWithTranslation extends React.Component {
-
-    static createConsoleMessage(type, message) {
-      createConsoleMessage(
-        type,
-        message,
-        {
-          strictMode: config.strictMode,
-          traceLimit: config.errorStackTraceLimit,
-        },
-      )
-    }
 
     constructor() {
       super()
@@ -82,7 +71,7 @@ export default function (WrappedComponent) {
       if (Array.isArray(pageProps.namespacesRequired)) {
         ({ namespacesRequired } = pageProps)
       }
-      this.createConsoleMessage(
+      consoleMessage(
         'warn',
         `You have not declared a namespacesRequired array on your page-level component: ${Component.displayName}. This will cause all namespaces to be sent down to the client, possibly negatively impacting the performance of your app. For more info, see: https://github.com/isaachinman/next-i18next#4-declaring-namespace-dependencies`,
       )

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -13,6 +13,17 @@ export default function (WrappedComponent) {
 
   class AppWithTranslation extends React.Component {
 
+    static createConsoleMessage(type, message) {
+      createConsoleMessage(
+        type,
+        message,
+        {
+          strictMode: config.strictMode,
+          traceLimit: config.errorStackTraceLimit,
+        },
+      )
+    }
+
     constructor() {
       super()
       if (config.localeSubpaths) {
@@ -24,19 +35,7 @@ export default function (WrappedComponent) {
               Router.replace(href, as, { shallow: true })
             }
           }
-
         })
-      }
-
-      this.createConsoleMessage = (type, message, traceLimit = 0) => {
-        createConsoleMessage(
-          type,
-          message,
-          {
-            strictMode: config.strictMode,
-            traceLimit,
-          },
-        )
       }
     }
 

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -82,12 +82,12 @@ export default function (WrappedComponent) {
       let namespacesRequired = config.ns
       if (Array.isArray(pageProps.namespacesRequired)) {
         ({ namespacesRequired } = pageProps)
-      } else if (process.env.NODE_ENV !== 'production') {
-        this.createConsoleMessage(
-          'warn',
-          `You have not declared a namespacesRequired array on your page-level component: ${Component.displayName}. This will cause all namespaces to be sent down to the client, possibly negatively impacting the performance of your app. For more info, see: https://github.com/isaachinman/next-i18next#4-declaring-namespace-dependencies`,
-        )
       }
+      this.createConsoleMessage(
+        'warn',
+        `You have not declared a namespacesRequired array on your page-level component: ${Component.displayName}. This will cause all namespaces to be sent down to the client, possibly negatively impacting the performance of your app. For more info, see: https://github.com/isaachinman/next-i18next#4-declaring-namespace-dependencies`,
+      )
+
 
       // We must always send down the defaultNS, otherwise
       // the client will trigger a request for it and issue

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import createConfig from 'config/create-config'
 import createI18NextClient from 'create-i18next-client'
 
 import { appWithTranslation } from 'hocs'
+import { consoleMessage } from 'utils'
 import { Link, Trans } from 'components'
 import { withNamespaces } from 'react-i18next'
 
@@ -9,6 +10,7 @@ export default class NextI18Next {
 
   constructor(userConfig) {
     this.config = createConfig(userConfig)
+    this.consoleMessage = consoleMessage.bind(this)
     this.i18n = createI18NextClient(this.config)
     this.appWithTranslation = appWithTranslation.bind(this)
     this.withNamespaces = withNamespaces

--- a/src/utils/console-message.js
+++ b/src/utils/console-message.js
@@ -39,27 +39,14 @@ function logMessage(PrettyError, messageType, message) {
   // Set the new error message
   newLog.message = message
 
-  if (messageType === messageTypes.error) {
-    newLog.name = capitalize(messageTypes.error)
-    console.error(pe.render(newLog))
-  }
-
-  if (messageType === messageTypes.info) {
+  if (Object.values(messageTypes).includes(messageType)) {
+    newLog.name = capitalize(messageTypes[messageType])
+    console[messageType](pe.render(newLog))
+  } else {
     newLog.name = capitalize(messageTypes.info)
     console.info(pe.render(newLog))
   }
 
-  if (messageType === messageTypes.warn) {
-    newLog.name = capitalize(messageTypes.warn)
-    console.warn(pe.render(newLog))
-  }
-
-  if (messageType !== messageTypes.error
-    && messageType !== messageTypes.info
-    && messageType !== messageTypes.warn) {
-    newLog.name = capitalize(messageTypes.info)
-    console.info(pe.render(newLog))
-  }
 }
 
 /**
@@ -68,18 +55,13 @@ function logMessage(PrettyError, messageType, message) {
  * @param {String} message
  * @param {Object} options
  */
-export default function createConsoleLog(
-  messageType,
-  message,
-  options = {
-    errorStackTraceLimit: 0,
-    strictMode: true,
-  }) {
-  const { errorStackTraceLimit, strictMode } = options
+export default function createConsoleLog(messageType, message) {
+
+  const { errorStackTraceLimit, strictMode } = this.config
+
   let util
   let PrettyError
   let pe
-
 
   if (!strictMode) {
     return

--- a/src/utils/console-message.js
+++ b/src/utils/console-message.js
@@ -1,45 +1,85 @@
 /* eslint-disable no-console */
 
-
 /**
   * @readonly
   * @enum {String} A console.log type
   */
 const messageTypes = {
-  warn: 'Warning',
-  err: 'Error',
-  info: 'Info',
+  error: 'error',
+  info: 'info',
+  warn: 'warn',
 }
 
 Object.freeze(messageTypes)
 
 /**
- * Sets the Error.stackTraceLimit to default or traceLimit
+ * Sets the Error.errorStackTraceLimit to default or errorStackTraceLimit
  * https://v8.dev/docs/stack-trace-api
- * @param {number} traceLimit
+ * @param {number} errorStackTraceLimit
  * @returns
  */
-function setStackTraceLimit(traceLimit = 10) {
-  Error.stackTraceLimit = traceLimit
+function setErrorStackTraceLimit(errorStackTraceLimit = 10) {
+  Error.stackTraceLimit = errorStackTraceLimit
 }
 
+/**
+ *  Logs a custom message to console
+ * @param {PrettyError} PrettyError
+ * @param {messageTypes} messageType One of: error, warn or info
+ * @param {String} message
+ */
+function logMessage(PrettyError, messageType, message) {
+  const capitalize = str => str.replace(str[0], str[0].toUpperCase())
+
+  const pe = new PrettyError()
+
+  // Create a new empty error
+  const newLog = new Error()
+
+  // Set the new error message
+  newLog.message = message
+
+  if (messageType === messageTypes.error) {
+    newLog.name = capitalize(messageTypes.error)
+    console.error(pe.render(newLog))
+  }
+
+  if (messageType === messageTypes.info) {
+    newLog.name = capitalize(messageTypes.info)
+    console.info(pe.render(newLog))
+  }
+
+  if (messageType === messageTypes.warn) {
+    newLog.name = capitalize(messageTypes.warn)
+    console.warn(pe.render(newLog))
+  }
+
+  if (messageType !== messageTypes.error
+    && messageType !== messageTypes.info
+    && messageType !== messageTypes.warn) {
+    newLog.name = capitalize(messageTypes.info)
+    console.info(pe.render(newLog))
+  }
+}
 
 /**
- * Create a console log with specified type, message and options
- * @param {messageTypes} messageType One of: err, warn or info
+ * Create a console log with specified log type, a message and options
+ * @param {messageTypes} messageType One of: error, warn or info
  * @param {String} message
  * @param {Object} options
  */
 export default function createConsoleLog(
-  messageType = messageTypes.info,
+  messageType,
   message,
   options = {
-    traceLimit: 0,
+    errorStackTraceLimit: 0,
     strictMode: true,
   }) {
-  const { traceLimit, strictMode } = options
+  const { errorStackTraceLimit, strictMode } = options
   let util
   let PrettyError
+  let pe
+
 
   if (!strictMode) {
     return
@@ -52,18 +92,19 @@ export default function createConsoleLog(
   if (process.env.NODE_ENV !== 'production') {
     util = require('util')
     PrettyError = require('pretty-error')
+
+    pe = new PrettyError()
+
   } else {
     return
   }
 
-  const pe = new PrettyError()
+  /* Temporarily set the stacktrace to 0 or errorStackTraceLimit,
+     in order to only display a message */
+  Error.errorStackTraceLimit = errorStackTraceLimit
 
-  /* Temporarily set the stacktrace to 0 or traceLimit, in order to only display a message */
-  Error.stackTraceLimit = traceLimit
-  /* Make room for new message */
+  // Make room for new message
   console.log()
-  // Create a new empty error
-  const newLog = new Error()
 
   // Make sure the message is a string
   if (typeof message !== 'string') {
@@ -82,28 +123,9 @@ export default function createConsoleLog(
     return
   }
 
-  // Set the new error message
-  newLog.message = message
+  // Log the message to console
+  logMessage(PrettyError, messageType, message)
 
-  switch (messageType) {
-    case 'warn':
-      newLog.name = messageTypes.warn
-      console.warn(pe.render(newLog))
-      setStackTraceLimit()
-      return
-    case 'err':
-      newLog.name = messageTypes.err
-      console.error(pe.render(newLog))
-      setStackTraceLimit()
-      return
-    case 'info':
-      newLog.name = messageTypes.info
-      console.info(pe.render(newLog))
-      setStackTraceLimit()
-      return
-    default:
-      newLog.name = messageTypes.info
-      console.info(pe.render(newLog))
-      setStackTraceLimit()
-  }
+  // Reset the Error.stackTraceLimit to 10
+  setErrorStackTraceLimit()
 }

--- a/src/utils/console-message.js
+++ b/src/utils/console-message.js
@@ -67,10 +67,6 @@ export default function createConsoleLog(messageType, message) {
     return
   }
 
-  if (process.env.NODE_ENV === 'test jest') {
-    return
-  }
-
   if (process.env.NODE_ENV !== 'production') {
     util = require('util')
     PrettyError = require('pretty-error')

--- a/src/utils/console-message.js
+++ b/src/utils/console-message.js
@@ -30,7 +30,7 @@ function setStackTraceLimit(traceLimit = 10) {
  * @param {String} message
  * @param {Object} options
  */
-function createConsoleLog(
+export default function createConsoleLog(
   messageType = messageTypes.info,
   message,
   options = {
@@ -38,12 +38,23 @@ function createConsoleLog(
     strictMode: true,
   }) {
   const { traceLimit, strictMode } = options
+  let util
+  let PrettyError
 
   if (!strictMode) {
     return
   }
-  const util = require('util')
-  const PrettyError = require('pretty-error')
+
+  if (process.env.NODE_ENV === 'test jest') {
+    return
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    util = require('util')
+    PrettyError = require('pretty-error')
+  } else {
+    return
+  }
 
   const pe = new PrettyError()
 
@@ -96,9 +107,3 @@ function createConsoleLog(
       setStackTraceLimit()
   }
 }
-
-/* Debugging */
-// createConsoleLog('warn', { test: 'object'})
-// createConsoleLog('info', 'Testing info messages')
-
-export default createConsoleLog

--- a/src/utils/console-message.js
+++ b/src/utils/console-message.js
@@ -1,12 +1,9 @@
 /* eslint-disable no-console */
-const util = require('util')
-const PrettyError = require('pretty-error')
 
-const pe = new PrettyError()
 
 /**
   * @readonly
-  * @enum {String} A log type
+  * @enum {String} A console.log type
   */
 const messageTypes = {
   warn: 'Warning',
@@ -28,14 +25,28 @@ function setStackTraceLimit(traceLimit = 10) {
 
 
 /**
- * Create a console log with specified type and message
- *
- * Optionally provide a traceLimit variable to increase the stack trace.
+ * Create a console log with specified type, message and options
  * @param {messageTypes} messageType One of: err, warn or info
  * @param {String} message
- * @param {Number} traceLimit
+ * @param {Object} options
  */
-function createConsoleLog(messageType = messageTypes.info, message, traceLimit = 0) {
+function createConsoleLog(
+  messageType = messageTypes.info,
+  message,
+  options = {
+    traceLimit: 0,
+    strictMode: true,
+  }) {
+  const { traceLimit, strictMode } = options
+
+  if (!strictMode) {
+    return
+  }
+  const util = require('util')
+  const PrettyError = require('pretty-error')
+
+  const pe = new PrettyError()
+
   /* Temporarily set the stacktrace to 0 or traceLimit, in order to only display a message */
   Error.stackTraceLimit = traceLimit
   /* Make room for new message */

--- a/src/utils/console-message.js
+++ b/src/utils/console-message.js
@@ -1,0 +1,93 @@
+/* eslint-disable no-console */
+const util = require('util')
+const PrettyError = require('pretty-error')
+
+const pe = new PrettyError()
+
+/**
+  * @readonly
+  * @enum {String} A log type
+  */
+const messageTypes = {
+  warn: 'Warning',
+  err: 'Error',
+  info: 'Info',
+}
+
+Object.freeze(messageTypes)
+
+/**
+ * Sets the Error.stackTraceLimit to default or traceLimit
+ * https://v8.dev/docs/stack-trace-api
+ * @param {number} traceLimit
+ * @returns
+ */
+function setStackTraceLimit(traceLimit = 10) {
+  Error.stackTraceLimit = traceLimit
+}
+
+
+/**
+ * Create a console log with specified type and message
+ *
+ * Optionally provide a traceLimit variable to increase the stack trace.
+ * @param {messageTypes} messageType One of: err, warn or info
+ * @param {String} message
+ * @param {Number} traceLimit
+ */
+function createConsoleLog(messageType = messageTypes.info, message, traceLimit = 0) {
+  /* Temporarily set the stacktrace to 0 or traceLimit, in order to only display a message */
+  Error.stackTraceLimit = traceLimit
+  /* Make room for new message */
+  console.log()
+  // Create a new empty error
+  const newLog = new Error()
+
+  // Make sure the message is a string
+  if (typeof message !== 'string') {
+    const metaError = new Error()
+    metaError.name = 'Meta'
+    metaError.message = `Param message needs to be of type: string. Instead, '${typeof message}' was provided.\n
+------------------------------------------------\n
+\u200b
+        The provided ${typeof message}:\n
+\u200b
+          ${util.inspect(message, true, 8, true)}
+\u200b
+------------------------------------------------\n
+    `
+    console.error(pe.render(metaError))
+    return
+  }
+
+  // Set the new error message
+  newLog.message = message
+
+  switch (messageType) {
+    case 'warn':
+      newLog.name = messageTypes.warn
+      console.warn(pe.render(newLog))
+      setStackTraceLimit()
+      return
+    case 'err':
+      newLog.name = messageTypes.err
+      console.error(pe.render(newLog))
+      setStackTraceLimit()
+      return
+    case 'info':
+      newLog.name = messageTypes.info
+      console.info(pe.render(newLog))
+      setStackTraceLimit()
+      return
+    default:
+      newLog.name = messageTypes.info
+      console.info(pe.render(newLog))
+      setStackTraceLimit()
+  }
+}
+
+/* Debugging */
+// createConsoleLog('warn', { test: 'object'})
+// createConsoleLog('info', 'Testing info messages')
+
+export default createConsoleLog

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
+export { default as createConsoleMessage } from './console-message.js'
 export { default as forceTrailingSlash } from './force-trailing-slash'
 export { default as lngPathCorrector } from './lng-path-corrector'
 export { default as lngPathDetector } from './lng-path-detector'

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,4 @@
-export { default as createConsoleMessage } from './console-message.js'
+export { default as consoleMessage } from './console-message.js'
 export { default as forceTrailingSlash } from './force-trailing-slash'
 export { default as lngPathCorrector } from './lng-path-corrector'
 export { default as lngPathDetector } from './lng-path-detector'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2458,7 +2458,7 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-css-select@~1.2.0:
+css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
@@ -2707,6 +2707,13 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-converter@~0.2:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
+  integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
+  dependencies:
+    utila "~0.4"
+
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -2737,10 +2744,24 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+domhandler@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.1.0.tgz#d2646f5e57f6c3bab11cf6cb05d3c0acf7412594"
+  integrity sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=
+  dependencies:
+    domelementtype "1"
+
 domhandler@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
+  dependencies:
+    domelementtype "1"
+
+domutils@1.1:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
+  integrity sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=
   dependencies:
     domelementtype "1"
 
@@ -3920,6 +3941,16 @@ htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^3.0.6"
 
+htmlparser2@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.3.0.tgz#cc70d05a59f6542e43f0e685c982e14c924a9efe"
+  integrity sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=
+  dependencies:
+    domelementtype "1"
+    domhandler "2.1"
+    domutils "1.1"
+    readable-stream "1.0"
+
 http-errors@1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
@@ -4428,6 +4459,11 @@ is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -6203,6 +6239,14 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+pretty-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
+  integrity sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=
+  dependencies:
+    renderkid "^2.0.1"
+    utila "~0.4"
+
 pretty-format@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
@@ -6520,6 +6564,16 @@ read-pkg@^4.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@1.0:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readable-stream@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.0.6.tgz#351302e4c68b5abd6a2ed55376a7f9a25be3057a"
@@ -6643,6 +6697,17 @@ remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
+renderkid@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.2.tgz#12d310f255360c07ad8fde253f6c9e9de372d2aa"
+  integrity sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==
+  dependencies:
+    css-select "^1.1.0"
+    dom-converter "~0.2"
+    htmlparser2 "~3.3.0"
+    strip-ansi "^3.0.0"
+    utila "^0.4.0"
 
 repeat-element@^1.1.2:
   version "1.1.3"
@@ -7311,6 +7376,11 @@ string_decoder@^1.0.0, string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -7781,6 +7851,11 @@ util@^0.10.3:
   integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
   dependencies:
     inherits "2.0.3"
+
+utila@^0.4.0, utila@~0.4:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
+  integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
 
 uuid@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
This enables users to set a strictMode boolean in their i18n config, that defines whether messages and errors are logged to the console.

So far I've not added an info message regarding traceLimit. I've added the `traceLimit` option because some errors would need a stack trace and that it's used in the function. Generally, the stack trace from pretty-error only contains standard modules and no helpful information, therefore it's quite unlikely that anyone would gain from being able to set the env variable. Nevertheless, I think, it does make sense to have it available.