### PR TITLE
Refactor appWithTranslation to work with custom routes

### DIFF
--- a/__tests__/utils/lng-path-corrector.test.js
+++ b/__tests__/utils/lng-path-corrector.test.js
@@ -5,7 +5,7 @@ import lngPathCorrector from '../../src/utils/lng-path-corrector'
 describe('lngPathCorrector utility function', () => {
   let config
   let i18n
-  let query
+  let currentRoute
 
   beforeEach(() => {
     config = {
@@ -17,32 +17,40 @@ describe('lngPathCorrector utility function', () => {
       languages: ['en', 'de'],
     }
 
-    query = {}
+    currentRoute = {
+      asPath: '/',
+      query: {},
+    }
   })
 
   it('throws if allLanguages does not include current language', () => {
     config.allLanguages = ['de', 'fr']
 
-    expect(() => lngPathCorrector(config, i18n, '/', query))
+    expect(() => lngPathCorrector(config, i18n, currentRoute))
       .toThrowError('Invalid configuration: Current language is not included in all languages array')
   })
 
   it('strips off the default language', () => {
-    expect(lngPathCorrector(config, i18n, '/en/foo', query)).toEqual(['/foo', { lng: 'en' }])
+    currentRoute.asPath = '/en/foo'
+
+    expect(lngPathCorrector(config, i18n, currentRoute)).toEqual(['/foo', { lng: 'en' }])
   })
 
   it('corrects path with language, if not the default', () => {
-    expect(lngPathCorrector(config, i18n, '/foo', query, 'de'))
+    currentRoute.asPath = '/foo'
+
+    expect(lngPathCorrector(config, i18n, currentRoute, 'de'))
       .toEqual(['/de/foo', { lng: 'de' }])
   })
 
   it('adds to query parameters, if some already exist', () => {
-    query.option1 = 'value1'
+    currentRoute.asPath = '/foo'
+    currentRoute.query.option1 = 'value1'
 
-    expect(lngPathCorrector(config, i18n, '/foo', query, 'de'))
+    expect(lngPathCorrector(config, i18n, currentRoute, 'de'))
       .toEqual(['/de/foo', { lng: 'de', option1: 'value1' }])
 
-    expect(lngPathCorrector(config, i18n, '/foo', query))
+    expect(lngPathCorrector(config, i18n, currentRoute))
       .toEqual(['/foo', { lng: 'en', option1: 'value1' }])
   })
 })

--- a/__tests__/utils/lng-path-corrector.test.js
+++ b/__tests__/utils/lng-path-corrector.test.js
@@ -33,7 +33,8 @@ describe('lngPathCorrector utility function', () => {
   it('strips off the default language', () => {
     currentRoute.asPath = '/en/foo'
 
-    expect(lngPathCorrector(config, i18n, currentRoute)).toEqual(['/foo', { lng: 'en' }])
+    // no 'lng ' parameter needed if this is the default language
+    expect(lngPathCorrector(config, i18n, currentRoute)).toEqual(['/foo', {}])
   })
 
   it('corrects path with language, if not the default', () => {
@@ -50,7 +51,8 @@ describe('lngPathCorrector utility function', () => {
     expect(lngPathCorrector(config, i18n, currentRoute, 'de'))
       .toEqual(['/de/foo', { lng: 'de', option1: 'value1' }])
 
+    // no 'lng ' parameter needed if this is the default language
     expect(lngPathCorrector(config, i18n, currentRoute))
-      .toEqual(['/foo', { lng: 'en', option1: 'value1' }])
+      .toEqual(['/foo', { option1: 'value1' }])
   })
 })

--- a/__tests__/utils/lng-path-corrector.test.js
+++ b/__tests__/utils/lng-path-corrector.test.js
@@ -5,6 +5,7 @@ import lngPathCorrector from '../../src/utils/lng-path-corrector'
 describe('lngPathCorrector utility function', () => {
   let config
   let i18n
+  let query
 
   beforeEach(() => {
     config = {
@@ -15,21 +16,33 @@ describe('lngPathCorrector utility function', () => {
     i18n = {
       languages: ['en', 'de'],
     }
+
+    query = {}
   })
 
   it('throws if allLanguages does not include current language', () => {
     config.allLanguages = ['de', 'fr']
 
-    expect(() => lngPathCorrector(config, i18n, '/'))
+    expect(() => lngPathCorrector(config, i18n, '/', query))
       .toThrowError('Invalid configuration: Current language is not included in all languages array')
   })
 
   it('strips off the default language', () => {
-    expect(lngPathCorrector(config, i18n, '/en/foo')).toEqual(['/foo', '/foo'])
+    expect(lngPathCorrector(config, i18n, '/en/foo', query)).toEqual(['/foo', { lng: 'en' }])
   })
 
   it('corrects path with language, if not the default', () => {
-    expect(lngPathCorrector(config, i18n, '/foo', 'de'))
-      .toEqual(['/foo?lng=de', '/de/foo'])
+    expect(lngPathCorrector(config, i18n, '/foo', query, 'de'))
+      .toEqual(['/de/foo', { lng: 'de' }])
+  })
+
+  it('adds to query parameters, if some already exist', () => {
+    query.option1 = 'value1'
+
+    expect(lngPathCorrector(config, i18n, '/foo', query, 'de'))
+      .toEqual(['/de/foo', { lng: 'de', option1: 'value1' }])
+
+    expect(lngPathCorrector(config, i18n, '/foo', query))
+      .toEqual(['/foo', { lng: 'en', option1: 'value1' }])
   })
 })

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -21,7 +21,7 @@ export default function (WrappedComponent) {
           if (process.browser) {
             const { router } = props
             const { pathname, asPath, query: routerQuery } = router
-            const [as, query] = lngPathCorrector(config, i18n, asPath, routerQuery, lng)
+            const [as, query] = lngPathCorrector(config, i18n, { asPath, query: routerQuery }, lng)
             if (as !== asPath) {
               router.replace({ pathname, query }, as, { shallow: true })
             }

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Router from 'next/router'
+import { withRouter } from 'next/router'
 
 import { I18nextProvider } from 'react-i18next'
 import { lngFromReq, lngPathCorrector } from 'utils'
@@ -13,15 +13,17 @@ export default function (WrappedComponent) {
 
   class AppWithTranslation extends React.Component {
 
-    constructor() {
-      super()
+    constructor(props) {
+      super(props)
+
       if (config.localeSubpaths) {
         i18n.on('languageChanged', (lng) => {
           if (process.browser) {
-            const originalRoute = window.location.pathname
-            const [href, as] = lngPathCorrector(config, i18n, originalRoute, lng)
-            if (as !== originalRoute) {
-              Router.replace(href, as, { shallow: true })
+            const { router } = props
+            const { pathname, asPath, query: routerQuery } = router
+            const [as, query] = lngPathCorrector(config, i18n, asPath, routerQuery, lng)
+            if (as !== asPath) {
+              router.replace({ pathname, query }, as, { shallow: true })
             }
           }
         })
@@ -145,6 +147,8 @@ export default function (WrappedComponent) {
     }
   }
 
-  return hoistNonReactStatics(AppWithTranslation, WrappedComponent, { getInitialProps: true })
+  return hoistNonReactStatics(
+    withRouter(AppWithTranslation), WrappedComponent, { getInitialProps: true },
+  )
 
 }

--- a/src/utils/lng-path-corrector.js
+++ b/src/utils/lng-path-corrector.js
@@ -1,6 +1,7 @@
-export default (config, i18n, asPath, query, currentLanguage = i18n.languages[0]) => {
+export default (config, i18n, currentRoute, currentLanguage = i18n.languages[0]) => {
 
   const { defaultLanguage, allLanguages } = config
+  const { asPath, query } = currentRoute
 
   if (!allLanguages.includes(currentLanguage)) {
     throw new Error('Invalid configuration: Current language is not included in all languages array')

--- a/src/utils/lng-path-corrector.js
+++ b/src/utils/lng-path-corrector.js
@@ -1,4 +1,4 @@
-export default (config, i18n, currentRoute, currentLanguage = i18n.languages[0]) => {
+export default (config, i18n, asPath, query, currentLanguage = i18n.languages[0]) => {
 
   const { defaultLanguage, allLanguages } = config
 
@@ -6,22 +6,18 @@ export default (config, i18n, currentRoute, currentLanguage = i18n.languages[0])
     throw new Error('Invalid configuration: Current language is not included in all languages array')
   }
 
-  let href = currentRoute
-  let as = href
+  let as = asPath
 
   for (const lng of allLanguages) {
-    if (href.startsWith(`/${lng}/`)) {
-      href = href.replace(`/${lng}/`, '/')
+    if (asPath.startsWith(`/${lng}/`)) {
+      as = as.replace(`/${lng}/`, '/')
       break
     }
   }
 
   if (currentLanguage !== defaultLanguage) {
-    as = `/${currentLanguage}${href}`
-    href += `?lng=${currentLanguage}`
-  } else {
-    as = href
+    return [`/${currentLanguage}${as}`, { ...query, lng: currentLanguage }]
   }
 
-  return [href, as]
+  return [as, { ...query, lng: defaultLanguage }]
 }

--- a/src/utils/lng-path-corrector.js
+++ b/src/utils/lng-path-corrector.js
@@ -20,5 +20,5 @@ export default (config, i18n, currentRoute, currentLanguage = i18n.languages[0])
     return [`/${currentLanguage}${as}`, { ...query, lng: currentLanguage }]
   }
 
-  return [as, { ...query, lng: defaultLanguage }]
+  return [as, query]
 }


### PR DESCRIPTION
We cannot use window.location.pathname in lngPathCorrector if the route is a custom route, since window.location.pathname !== router.pathname (instead, it is equal to router.asPath).  Since this is the case, [we cannot use shallow routing](https://github.com/zeit/next.js/blob/canary/packages/next-server/lib/router/router.js#L374-L375) and a new page is requested, resulting in a 404 error whenever the i18n.changeLanguage function is invoked.

This commit changes appWithTranslation to instead use the withRouter Next HoC, which exposes a router prop.  The router prop has pathname, query, and asPath attributes which we can use instead of using window.location.pathname.  We then modify query and asPath in lngPathCorrector (as pathname will remain unchanged if we are only changing the language) and shallow route if the asPath has changed after correction (with query being modified, as necessary).

Also fixes #126 by ensuring that existing query parameters are preserved.