### PR TITLE
Removing dead code from test

### DIFF
--- a/__tests__/components/Link.test.js
+++ b/__tests__/components/Link.test.js
@@ -19,10 +19,6 @@ describe('Link component', () => {
       localeSubpaths: false,
     }
 
-    context.i18n = {
-      languages: ['de', 'en'],
-    }
-
     context.withNamespaces = () => Component => Component
 
     props = {


### PR DESCRIPTION
We don't need i18n.languages anymore