### PR TITLE
Add customDetectors option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ class SomeLink extends React.Component {
 | `localeSubpaths` | `false`  |
 | `serverLanguageDetection` | `true`  |
 | `use` (for plugins) | `[]`  |
+| `customDetectors` | `[]`  |
 
 _This table contains options which are specific to next-i18next. All other [i18next options](https://www.i18next.com/overview/configuration-options) can be passed in as well._
 

--- a/__tests__/create-i18next-client.test.js
+++ b/__tests__/create-i18next-client.test.js
@@ -1,0 +1,110 @@
+/* eslint-env jest */
+import i18next from 'i18next'
+import I18nextBrowserLanguageDetector from 'i18next-browser-languagedetector'
+import createI18nextClient from '../src/create-i18next-client'
+
+const i18nextMiddleware = require('i18next-express-middleware')
+
+jest.mock('i18next', () => ({
+  init: jest.fn(),
+  use: jest.fn(),
+}))
+
+jest.mock('i18next-express-middleware', () => ({
+  LanguageDetector: jest.fn(),
+}))
+
+jest.mock('i18next-browser-languagedetector', () => jest.fn())
+
+describe('initializing i18n', () => {
+  beforeEach(() => {
+    i18next.isInitialized = false
+  })
+
+  afterEach(() => {
+    i18next.init.mockClear()
+    i18next.use.mockClear()
+    i18nextMiddleware.LanguageDetector.mockClear()
+  })
+
+  it('should not initialize i18n if i18n is already initialized', () => {
+    i18next.isInitialized = true
+
+    createI18nextClient({
+      use: [],
+      customDetectors: [],
+      serverLanguageDetection: true,
+      browserLanguageDetection: true,
+    })
+
+    expect(i18next.init).not.toBeCalled()
+    expect(i18next.use).not.toBeCalled()
+  })
+
+  it('should initialize i18n if i18n is not yet initialized', () => {
+    i18next.isInitialized = false
+
+    createI18nextClient({
+      use: [],
+      customDetectors: [],
+      serverLanguageDetection: true,
+      browserLanguageDetection: true,
+    })
+
+    expect(i18next.use).toBeCalledTimes(2)
+    expect(i18next.init).toBeCalledTimes(1)
+  })
+
+  it('should add backend language detector if on node environment', () => {
+    i18next.isInitialized = false
+
+    createI18nextClient({
+      use: [],
+      customDetectors: [],
+      serverLanguageDetection: true,
+    })
+
+    expect(i18nextMiddleware.LanguageDetector).toBeCalled()
+    expect(I18nextBrowserLanguageDetector).not.toBeCalled()
+    expect(i18next.use).toBeCalledTimes(2)
+    expect(i18next.init).toBeCalled()
+  })
+
+  it('should call addDetector with the right detector if serverLanguageDetection is true', () => {
+    i18next.isInitialized = false
+    const addDetector = jest.fn()
+    i18nextMiddleware.LanguageDetector.mockImplementation(() => ({
+      addDetector,
+    }))
+
+    createI18nextClient({
+      use: [],
+      customDetectors: ['test_custom_detector'],
+      serverLanguageDetection: true,
+    })
+    expect(i18nextMiddleware.LanguageDetector).toBeCalled()
+    expect(I18nextBrowserLanguageDetector).not.toBeCalled()
+    expect(addDetector).toBeCalledWith('test_custom_detector')
+    expect(i18next.use).toBeCalledTimes(2)
+    expect(i18next.init).toBeCalledTimes(1)
+  })
+
+  it('should not call addDetector with the right detector if serverLanguageDetection is false', () => {
+    i18next.isInitialized = false
+    const addDetector = jest.fn()
+    i18nextMiddleware.LanguageDetector.mockImplementation(() => ({
+      addDetector,
+    }))
+
+    createI18nextClient({
+      use: [],
+      customDetectors: ['test_custom_detector'],
+      serverLanguageDetection: false,
+    })
+    expect(i18nextMiddleware.LanguageDetector).not.toBeCalled()
+    expect(I18nextBrowserLanguageDetector).not.toBeCalled()
+    expect(addDetector).not.toBeCalled()
+    expect(i18next.use).toBeCalledTimes(1)
+    expect(i18next.init).toBeCalledTimes(1)
+  })
+})

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -24,6 +24,7 @@ export default {
   browserLanguageDetection: true,
   serverLanguageDetection: true,
   ignoreRoutes: ['/_next', '/static'],
+  customDetectors: [],
   detection: {
     order: ['cookie', 'header', 'querystring'],
     caches: ['cookie'],

--- a/src/create-i18next-client.js
+++ b/src/create-i18next-client.js
@@ -1,7 +1,7 @@
 import isNode from 'detect-node'
 import i18next from 'i18next'
 import i18nextXHRBackend from 'i18next-xhr-backend'
-import i18nextBrowserLanguageDetector from 'i18next-browser-languagedetector'
+import I18nextBrowserLanguageDetector from 'i18next-browser-languagedetector'
 
 const i18n = i18next.default ? i18next.default : i18next
 i18n.nsFromReactTree = []
@@ -14,12 +14,16 @@ export default (config) => {
       const i18nextMiddleware = eval("require('i18next-express-middleware')")
       i18n.use(i18nextNodeBackend)
       if (config.serverLanguageDetection) {
-        i18n.use(i18nextMiddleware.LanguageDetector)
+        const serverDetectors = new i18nextMiddleware.LanguageDetector()
+        config.customDetectors.forEach(detector => serverDetectors.addDetector(detector))
+        i18n.use(serverDetectors)
       }
     } else {
       i18n.use(i18nextXHRBackend)
       if (config.browserLanguageDetection) {
-        i18n.use(i18nextBrowserLanguageDetector)
+        const browserDetectors = new I18nextBrowserLanguageDetector()
+        config.customDetectors.forEach(detector => browserDetectors.addDetector(detector))
+        i18n.use(browserDetectors)
       }
     }
 


### PR DESCRIPTION
I want to start a discussion about this feature

## Motivation

A while a go we were discussing custom language detectors and @isaachinman implemented the option to add plugins to next-i18next (https://github.com/isaachinman/next-i18next/commit/14d494fc0e871a509d4214d1523fa7cade33e13b).

However this was exclusively for plugins, which doesn't work with the custom language detectors interface provided by `i18n`.

Adding this feature makes it easier for users develop their own language detector and use it with the following interface and options:

Interface
```js
export default {
  name: 'myDetectorsName',

  lookup(options) {
    // options -> are passed in options
    return 'en';
  },

  cacheUserLanguage(lng, options) {
    // options -> are passed in options
    // lng -> current language, will be called after init and on changeLanguage

    // store it
  }
};
```

Options
```js
{
  // order and from where user language should be detected
  order: ['querystring', 'cookie', 'localStorage', 'navigator', 'htmlTag', 'path', 'subdomain'],

  // keys or params to lookup language from
  lookupQuerystring: 'lng',
  lookupCookie: 'i18next',
  lookupLocalStorage: 'i18nextLng',
  lookupFromPathIndex: 0,
  lookupFromSubdomainIndex: 0,

  // cache user language on
  caches: ['localStorage', 'cookie'],
  excludeCacheFor: ['cimode'], // languages to not persist (cookie, localStorage)

  // optional expire and domain for set cookie
  cookieMinutes: 10,
  cookieDomain: 'myDomain',

  // optional htmlTag with lang attribute, the default is:
  htmlTag: document.documentElement
}
```


## Questions

1. There is a specific reason to use `eval` here: `eval("require('i18next-express-middleware')")`
2. Why are we using `isNode` ? Isn't `process.browser` enough?





