### PR TITLE
Use Component.name if Component.displayName is undefined

### DIFF
--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -72,7 +72,7 @@ export default function (WrappedComponent) {
       } else {
         consoleMessage(
           'warn',
-          `You have not declared a namespacesRequired array on your page-level component: ${Component.displayName}. This will cause all namespaces to be sent down to the client, possibly negatively impacting the performance of your app. For more info, see: https://github.com/isaachinman/next-i18next#4-declaring-namespace-dependencies`,
+          `You have not declared a namespacesRequired array on your page-level component: ${Component.displayName || Component.name || 'Component'}. This will cause all namespaces to be sent down to the client, possibly negatively impacting the performance of your app. For more info, see: https://github.com/isaachinman/next-i18next#4-declaring-namespace-dependencies`,
         )
       }
 


### PR DESCRIPTION
Sometimes, `Component.displayName` is not defined, causing our `namespacesRequired` warning to print `undefined`.  But we can fallback to `Component.name` instead.

As a final fallback, in the event that `name` and `displayName` are both `undefined`, just print 'Component'.

Resolves #112.