### PR TITLE
Adding HoC to handle passing config to React components

### DIFF
--- a/__tests__/components/Link.test.js
+++ b/__tests__/components/Link.test.js
@@ -18,8 +18,10 @@ describe('Link component', () => {
       href: '/foo/bar',
       lng: 'de',
       nextI18NextConfig: {
-        defaultLanguage: 'en',
-        localeSubpaths: false,
+        config: {
+          defaultLanguage: 'en',
+          localeSubpaths: false,
+        },
       },
     }
   })
@@ -44,7 +46,7 @@ describe('Link component', () => {
   })
 
   it('renders without lang if props.lng is undefined', () => {
-    props.nextI18NextConfig.localeSubpaths = true
+    props.nextI18NextConfig.config.localeSubpaths = true
     props.lng = undefined
 
     // without 'as' prop
@@ -62,8 +64,8 @@ describe('Link component', () => {
   })
 
   it('renders without lang if props.lng === defaultLanguage', () => {
-    props.nextI18NextConfig.localeSubpaths = true
-    props.nextI18NextConfig.defaultLanguage = 'en'
+    props.nextI18NextConfig.config.localeSubpaths = true
+    props.nextI18NextConfig.config.defaultLanguage = 'en'
     props.lng = 'en'
 
     // without 'as' prop
@@ -81,8 +83,8 @@ describe('Link component', () => {
   })
 
   it('renders with lang', () => {
-    props.nextI18NextConfig.localeSubpaths = true
-    props.nextI18NextConfig.defaultLanguage = 'en'
+    props.nextI18NextConfig.config.localeSubpaths = true
+    props.nextI18NextConfig.config.defaultLanguage = 'en'
 
     // without 'as' prop -- no query parameters
     let component = createLinkComponent()

--- a/__tests__/components/Link.test.js
+++ b/__tests__/components/Link.test.js
@@ -3,39 +3,30 @@
 import React from 'react'
 import { mount } from 'enzyme'
 
-import linkFunction from '../../src/components/Link'
+import Link from '../../src/components/Link'
 
 jest.mock('next/link')
+jest.mock('react-i18next', () => ({
+  withNamespaces: () => Component => Component,
+}))
 
 describe('Link component', () => {
-  let context
   let props
 
   beforeEach(() => {
-    context = {}
-
-    context.config = {
-      defaultLanguage: 'en',
-      localeSubpaths: false,
-    }
-
-    context.i18n = {
-      languages: ['de', 'en'],
-    }
-
-    context.withNamespaces = () => Component => Component
-
     props = {
       href: '/foo/bar',
       lng: 'de',
+      nextI18NextConfig: {
+        defaultLanguage: 'en',
+        localeSubpaths: false,
+      },
     }
   })
 
-  const createLinkComponent = (otherProps = {}) => {
-    const Link = linkFunction.apply(context)
-
-    return mount(<Link {...props} {...otherProps}>click here</Link>).find('Link').at(1)
-  }
+  const createLinkComponent = (otherProps = {}) => mount(
+    <Link {...props} {...otherProps}>click here</Link>,
+  ).find('Link').at(1)
 
   it('renders without lang if localeSubpaths === false', () => {
     // without 'as' prop
@@ -53,7 +44,7 @@ describe('Link component', () => {
   })
 
   it('renders without lang if props.lng is undefined', () => {
-    context.config.localeSubpaths = true
+    props.nextI18NextConfig.localeSubpaths = true
     props.lng = undefined
 
     // without 'as' prop
@@ -71,8 +62,8 @@ describe('Link component', () => {
   })
 
   it('renders without lang if props.lng === defaultLanguage', () => {
-    context.config.localeSubpaths = true
-    context.config.defaultLanguage = 'en'
+    props.nextI18NextConfig.localeSubpaths = true
+    props.nextI18NextConfig.defaultLanguage = 'en'
     props.lng = 'en'
 
     // without 'as' prop
@@ -90,8 +81,8 @@ describe('Link component', () => {
   })
 
   it('renders with lang', () => {
-    context.config.localeSubpaths = true
-    context.config.defaultLanguage = 'en'
+    props.nextI18NextConfig.localeSubpaths = true
+    props.nextI18NextConfig.defaultLanguage = 'en'
 
     // without 'as' prop -- no query parameters
     let component = createLinkComponent()

--- a/__tests__/components/Trans.test.js
+++ b/__tests__/components/Trans.test.js
@@ -4,38 +4,29 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { Trans as ReactTrans } from 'react-i18next'
 
-import transFunction from '../../src/components/Trans'
+import Trans from '../../src/components/Trans'
 
 jest.mock('react-i18next', () => ({
   Trans: () => 'mock-trans',
+  withNamespaces: () => Component => Component,
 }))
 
 describe('Trans component', () => {
-  let context
   let props
 
   beforeEach(() => {
-    context = {}
-
-    context.i18n = {
-      languages: ['de', 'en'],
-    }
-
     props = {
+      i18n: {
+        languages: ['de', 'en'],
+      },
       i18nKey: 'title',
     }
   })
 
-  const createTransComponent = () => {
-    const Trans = transFunction.apply(context)
-
-    return mount(<Trans {...props} />)
-  }
-
   it('renders react-i18next Trans component with props and i18n prop', () => {
-    const component = createTransComponent()
+    const component = mount(<Trans {...props} />)
 
-    expect(component.find(ReactTrans).prop('i18n')).toEqual(context.i18n)
+    expect(component.find(ReactTrans).prop('i18n')).toEqual({ languages: ['de', 'en'] })
     expect(component.find(ReactTrans).prop('i18nKey')).toEqual('title')
   })
 })

--- a/__tests__/components/Trans.test.js
+++ b/__tests__/components/Trans.test.js
@@ -8,7 +8,6 @@ import Trans from '../../src/components/Trans'
 
 jest.mock('react-i18next', () => ({
   Trans: () => 'mock-trans',
-  withNamespaces: () => Component => Component,
 }))
 
 describe('Trans component', () => {
@@ -16,10 +15,12 @@ describe('Trans component', () => {
 
   beforeEach(() => {
     props = {
-      i18n: {
-        languages: ['de', 'en'],
-      },
       i18nKey: 'title',
+      nextI18NextConfig: {
+        i18n: {
+          languages: ['de', 'en'],
+        },
+      },
     }
   })
 

--- a/__tests__/hocs/with-config.test.js
+++ b/__tests__/hocs/with-config.test.js
@@ -1,0 +1,75 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { mount } from 'enzyme'
+
+import { withConfig } from 'hocs'
+
+describe('withConfig HoC', () => {
+  let config
+  let props
+  let WrappedComponent
+
+  beforeEach(() => {
+    config = { localeSubpaths: true }
+    props = {}
+    WrappedComponent = () => <div />
+  })
+
+  it('adds nextI18NextConfig prop to component', () => {
+    const Component = withConfig(WrappedComponent, config)
+
+    expect(mount(<Component />).find('WrappedComponent').prop('nextI18NextConfig'))
+      .toEqual({ localeSubpaths: true })
+  })
+
+  it('passes other props into wrapped component', () => {
+    props.prop = 'value'
+
+    const Component = withConfig(WrappedComponent, config)
+
+    const wrappedComponent = mount(<Component {...props} />).find('WrappedComponent')
+    expect(wrappedComponent.prop('nextI18NextConfig')).toEqual({ localeSubpaths: true })
+    expect(wrappedComponent.prop('prop')).toEqual('value')
+  })
+
+  describe('getInitialProps', () => {
+    const ctx = {}
+
+    it('returns empty object if getInitialProps of wrapped component does not exist', async () => {
+      const Component = withConfig(WrappedComponent, config)
+
+      expect(await Component.getInitialProps(ctx)).toEqual({})
+    })
+
+    it('calls getInitialProps of wrapped component, if it exists', async () => {
+      WrappedComponent.getInitialProps = jest.fn(() => Promise.resolve({ prop: 'value' }))
+      const Component = withConfig(WrappedComponent, config)
+
+      expect(await Component.getInitialProps(ctx)).toEqual({ prop: 'value' })
+      expect(WrappedComponent.getInitialProps).toBeCalledWith(ctx)
+    })
+  })
+
+  describe('displayName', () => {
+    it('renders with Component displayName, if displayName available', () => {
+      WrappedComponent.displayName = 'withAnotherHoC(WrappedComponent)'
+      const Component = withConfig(WrappedComponent, config)
+
+      expect(Component.displayName)
+        .toEqual('withNextI18NextConfig(withAnotherHoC(WrappedComponent))')
+    })
+
+    it('renders Component name, if displayName not available', () => {
+      const Component = withConfig(WrappedComponent, config)
+
+      expect(Component.displayName).toEqual('withNextI18NextConfig(WrappedComponent)')
+    })
+
+    it('renders "Component" for Component name, if no names available', () => {
+      const Component = withConfig(<div />, config)
+
+      expect(Component.displayName).toEqual('withNextI18NextConfig(Component)')
+    })
+  })
+})

--- a/__tests__/hocs/with-config.test.js
+++ b/__tests__/hocs/with-config.test.js
@@ -33,24 +33,6 @@ describe('withConfig HoC', () => {
     expect(wrappedComponent.prop('prop')).toEqual('value')
   })
 
-  describe('getInitialProps', () => {
-    const ctx = {}
-
-    it('returns empty object if getInitialProps of wrapped component does not exist', async () => {
-      const Component = withConfig(WrappedComponent, config)
-
-      expect(await Component.getInitialProps(ctx)).toEqual({})
-    })
-
-    it('calls getInitialProps of wrapped component, if it exists', async () => {
-      WrappedComponent.getInitialProps = jest.fn(() => Promise.resolve({ prop: 'value' }))
-      const Component = withConfig(WrappedComponent, config)
-
-      expect(await Component.getInitialProps(ctx)).toEqual({ prop: 'value' })
-      expect(WrappedComponent.getInitialProps).toBeCalledWith(ctx)
-    })
-  })
-
   describe('displayName', () => {
     it('renders with Component displayName, if displayName available', () => {
       WrappedComponent.displayName = 'withAnotherHoC(WrappedComponent)'

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -37,9 +37,9 @@ const removeWithNamespacesProps = (props) => {
 class Link extends React.Component {
   render() {
     const {
-      as, children, href, lng, nextI18NextConfig: config, ...props
+      as, children, href, lng, nextI18NextConfig, ...props
     } = this.props
-    const { defaultLanguage, localeSubpaths } = config
+    const { defaultLanguage, localeSubpaths } = nextI18NextConfig.config
     if (localeSubpaths && lng && lng !== defaultLanguage) {
       const { pathname, query } = parseUrl(href, true /* parseQueryString */)
 
@@ -75,8 +75,10 @@ Link.propTypes = {
   ]).isRequired,
   lng: PropTypes.string,
   nextI18NextConfig: PropTypes.shape({
-    defaultLanguage: PropTypes.string.isRequired,
-    localeSubpaths: PropTypes.bool.isRequired,
+    config: PropTypes.shape({
+      defaultLanguage: PropTypes.string.isRequired,
+      localeSubpaths: PropTypes.bool.isRequired,
+    }).isRequired,
   }).isRequired,
 }
 

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -19,6 +19,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
+import { withNamespaces } from 'react-i18next'
 import { parse as parseUrl } from 'url'
 
 const removeWithNamespacesProps = (props) => {
@@ -33,59 +34,59 @@ const removeWithNamespacesProps = (props) => {
   return strippedProps
 }
 
-export default function () {
-
-  const { config } = this
-
-  class Link extends React.Component {
-    render() {
-      const { defaultLanguage, localeSubpaths } = config
-      const {
-        as, children, href, lng, ...props
-      } = this.props
-      if (localeSubpaths && lng && lng !== defaultLanguage) {
-        const { pathname, query } = parseUrl(href, true /* parseQueryString */)
-
-        return (
-          <NextLink
-            href={{ pathname, query: { ...query, lng } }}
-            as={`/${lng}${as || href}`}
-            {...removeWithNamespacesProps(props)}
-          >
-            {children}
-          </NextLink>
-        )
-      }
+class Link extends React.Component {
+  render() {
+    const {
+      as, children, href, lng, nextI18NextConfig: config, ...props
+    } = this.props
+    const { defaultLanguage, localeSubpaths } = config
+    if (localeSubpaths && lng && lng !== defaultLanguage) {
+      const { pathname, query } = parseUrl(href, true /* parseQueryString */)
 
       return (
         <NextLink
-          href={href}
-          as={as}
+          href={{ pathname, query: { ...query, lng } }}
+          as={`/${lng}${as || href}`}
           {...removeWithNamespacesProps(props)}
         >
           {children}
         </NextLink>
       )
     }
+
+    return (
+      <NextLink
+        href={href}
+        as={as}
+        {...removeWithNamespacesProps(props)}
+      >
+        {children}
+      </NextLink>
+    )
   }
-
-  Link.propTypes = {
-    as: PropTypes.string,
-    children: PropTypes.node.isRequired,
-    href: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object,
-    ]).isRequired,
-  }
-
-  Link.defaultProps = {
-    as: undefined,
-  }
-
-  /*
-    Usage of `withNamespaces` here is just to
-    force `Link` to rerender on language change
-  */
-  return this.withNamespaces()(Link)
-
 }
+
+Link.propTypes = {
+  as: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  href: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]).isRequired,
+  lng: PropTypes.string,
+  nextI18NextConfig: PropTypes.shape({
+    defaultLanguage: PropTypes.string.isRequired,
+    localeSubpaths: PropTypes.bool.isRequired,
+  }).isRequired,
+}
+
+Link.defaultProps = {
+  as: undefined,
+  lng: undefined,
+}
+
+/*
+  Usage of `withNamespaces` here is just to
+  force `Link` to rerender on language change
+*/
+export default withNamespaces()(Link)

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -73,7 +73,6 @@ Link.propTypes = {
     PropTypes.string,
     PropTypes.object,
   ]).isRequired,
-  lng: PropTypes.string,
   nextI18NextConfig: PropTypes.shape({
     config: PropTypes.shape({
       defaultLanguage: PropTypes.string.isRequired,
@@ -84,7 +83,6 @@ Link.propTypes = {
 
 Link.defaultProps = {
   as: undefined,
-  lng: undefined,
 }
 
 /*

--- a/src/components/Trans.js
+++ b/src/components/Trans.js
@@ -1,14 +1,13 @@
 import React from 'react'
-import { Trans, withNamespaces } from 'react-i18next'
+import { Trans } from 'react-i18next'
 
-class WrappedTrans extends React.Component {
+export default class WrappedTrans extends React.Component {
   render() {
-    const { i18n } = this.props
+    const { nextI18NextConfig } = this.props
+    const { i18n } = nextI18NextConfig
 
     return (
       <Trans {...this.props} i18n={i18n} />
     )
   }
 }
-
-export default withNamespaces()(WrappedTrans)

--- a/src/components/Trans.js
+++ b/src/components/Trans.js
@@ -1,16 +1,14 @@
 import React from 'react'
-import { Trans } from 'react-i18next'
+import { Trans, withNamespaces } from 'react-i18next'
 
-export default function () {
+class WrappedTrans extends React.Component {
+  render() {
+    const { i18n } = this.props
 
-  const { i18n } = this
-
-  return class WrappedTrans extends React.Component {
-    render() {
-      return (
-        <Trans {...this.props} i18n={i18n} />
-      )
-    }
+    return (
+      <Trans {...this.props} i18n={i18n} />
+    )
   }
-
 }
+
+export default withNamespaces()(WrappedTrans)

--- a/src/hocs/index.js
+++ b/src/hocs/index.js
@@ -1,1 +1,2 @@
-export { default as appWithTranslation } from './app-with-translation' // eslint-disable-line import/prefer-default-export
+export { default as appWithTranslation } from './app-with-translation'
+export { default as withConfig } from './with-config'

--- a/src/hocs/with-config.js
+++ b/src/hocs/with-config.js
@@ -1,0 +1,26 @@
+import React from 'react'
+
+export default (WrappedComponent, config) => {
+  class WithConfig extends React.Component {
+    static getInitialProps(ctx) {
+      if (WrappedComponent.getInitialProps) {
+        return WrappedComponent.getInitialProps(ctx)
+      }
+
+      return {}
+    }
+
+    render() {
+      return (
+        <WrappedComponent
+          {...this.props}
+          nextI18NextConfig={config}
+        />
+      )
+    }
+  }
+
+  WithConfig.displayName = `withNextI18NextConfig(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`
+
+  return WithConfig
+}

--- a/src/hocs/with-config.js
+++ b/src/hocs/with-config.js
@@ -2,14 +2,6 @@ import React from 'react'
 
 export default (WrappedComponent, config) => {
   class WithConfig extends React.Component {
-    static getInitialProps(ctx) {
-      if (WrappedComponent.getInitialProps) {
-        return WrappedComponent.getInitialProps(ctx)
-      }
-
-      return {}
-    }
-
     render() {
       return (
         <WrappedComponent

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import createConfig from 'config/create-config'
 import createI18NextClient from 'create-i18next-client'
 
-import { appWithTranslation } from 'hocs'
+import { appWithTranslation, withConfig } from 'hocs'
 import { consoleMessage } from 'utils'
 import { Link, Trans } from 'components'
 import { withNamespaces } from 'react-i18next'
@@ -15,8 +15,8 @@ export default class NextI18Next {
     this.appWithTranslation = appWithTranslation.bind(this)
     this.withNamespaces = withNamespaces
 
-    this.Trans = Trans.apply(this)
-    this.Link = Link.apply(this)
+    this.Trans = Trans
+    this.Link = withConfig(Link, this.config)
   }
 
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,9 @@ export default class NextI18Next {
     this.appWithTranslation = appWithTranslation.bind(this)
     this.withNamespaces = withNamespaces
 
-    this.Trans = Trans
-    this.Link = withConfig(Link, this.config)
+    const nextI18NextConfig = { config: this.config, i18n: this.i18n }
+    this.Trans = withConfig(Trans, nextI18NextConfig)
+    this.Link = withConfig(Link, nextI18NextConfig)
   }
 
 }


### PR DESCRIPTION
An example implementation of how we could use a higher-order component to pass configuration on to our React components that require configuration.

Ref #113.