### PR TITLE
Implement lng-from-req to use req.i18n.language

### DIFF
--- a/src/utils/lng-from-req.js
+++ b/src/utils/lng-from-req.js
@@ -1,11 +1,9 @@
 export default (req) => {
-
   const { allLanguages, defaultLanguage, fallbackLng } = req.i18n.options
 
-  const language = req.i18n.languages.find(l => allLanguages.includes(l))
+  const language = req.i18n.languages.find(l => req.i18n.language || allLanguages.includes(l))
     || fallbackLng
     || defaultLanguage
 
   return language
-
 }


### PR DESCRIPTION
Not exactly sure on the intention of ``allLanguages.includes(l)`` in this method (lng-from-req) but I am assuming [i18next-express-middleware](https://github.com/i18next/i18next-express-middleware) already provides the current language selected in req.i18n object. Ref [here](https://github.com/i18next/i18next-express-middleware/blob/master/src/index.js#L43)

Using these changes in PR solved this issue (Ref:  #120) for me without breaking other feature I have currently implemented. 