### PR TITLE
Ensure client is properly configured with custom localePath

### DIFF
--- a/__tests__/config/create-config.test.js
+++ b/__tests__/config/create-config.test.js
@@ -91,6 +91,34 @@ describe('create configuration in non-production environment', () => {
       expect(config.backend.loadPath).toEqual('/home/user/static/translations/{{ns}}/{{lng}}.json')
       expect(config.backend.addPath).toEqual('/home/user/static/translations/{{ns}}/{{lng}}.missing.json')
     })
+
+    it('does not overwrite loadPath if user has specified one', () => {
+      const userConfigWithLoadPath = {
+        ...userConfig,
+        backend: {
+          loadPath: '/static/custom/path/{{ns}}/{{lng}}.json',
+        },
+      }
+
+      const config = createConfig(userConfigWithLoadPath)
+
+      expect(config.backend.loadPath)
+        .toEqual('/home/user/static/custom/path/{{ns}}/{{lng}}.json')
+    })
+
+    it('does not overwrite addPath if user has specified one', () => {
+      const userConfigWithAddPath = {
+        ...userConfig,
+        backend: {
+          addPath: '/static/custom/path/{{ns}}/{{lng}}.missing.json',
+        },
+      }
+
+      const config = createConfig(userConfigWithAddPath)
+
+      expect(config.backend.addPath)
+        .toEqual('/home/user/static/custom/path/{{ns}}/{{lng}}.missing.json')
+    })
   })
 
   const runClientSideTests = () => {
@@ -146,6 +174,34 @@ describe('create configuration in non-production environment', () => {
         .toEqual('/static/translations/{{ns}}/{{lng}}.json')
       expect(config.backend.addPath)
         .toEqual('/static/translations/{{ns}}/{{lng}}.missing.json')
+    })
+
+    it('does not overwrite loadPath if user has specified one', () => {
+      const userConfigWithLoadPath = {
+        ...userConfig,
+        backend: {
+          loadPath: '/static/custom/path/{{ns}}/{{lng}}.json',
+        },
+      }
+
+      const config = createConfig(userConfigWithLoadPath)
+
+      expect(config.backend.loadPath)
+        .toEqual('/static/custom/path/{{ns}}/{{lng}}.json')
+    })
+
+    it('does not overwrite addPath if user has specified one', () => {
+      const userConfigWithAddPath = {
+        ...userConfig,
+        backend: {
+          addPath: '/static/custom/path/{{ns}}/{{lng}}.missing.json',
+        },
+      }
+
+      const config = createConfig(userConfigWithAddPath)
+
+      expect(config.backend.addPath)
+        .toEqual('/static/custom/path/{{ns}}/{{lng}}.missing.json')
     })
   }
 

--- a/__tests__/config/create-config.test.js
+++ b/__tests__/config/create-config.test.js
@@ -142,8 +142,10 @@ describe('create configuration in non-production environment', () => {
 
       expect(config.ns).toEqual(['universal'])
 
-      expect(config.backend.loadPath).toEqual('/static/locales/{{lng}}/{{ns}}.json')
-      expect(config.backend.addPath).toEqual('/static/locales/{{lng}}/{{ns}}.missing.json')
+      expect(config.backend.loadPath)
+        .toEqual('/static/translations/{{ns}}/{{lng}}.json')
+      expect(config.backend.addPath)
+        .toEqual('/static/translations/{{ns}}/{{lng}}.missing.json')
     })
   }
 

--- a/src/config/create-config.js
+++ b/src/config/create-config.js
@@ -18,13 +18,16 @@ export default (userConfig) => {
     .concat([combinedConfig.defaultLanguage])
   combinedConfig.ns = [combinedConfig.defaultNS]
 
+  const {
+    localePath, localeStructure,
+  } = combinedConfig
   if (isNode && !process.browser) {
     const fs = eval("require('fs')")
     const path = require('path')
 
     const getAllNamespaces = p => fs.readdirSync(p).map(file => file.replace('.json', ''))
     const {
-      allLanguages, defaultLanguage, localePath, localeStructure,
+      allLanguages, defaultLanguage,
     } = combinedConfig
 
     combinedConfig = {
@@ -34,6 +37,14 @@ export default (userConfig) => {
       backend: {
         loadPath: path.join(process.cwd(), `${localePath}/${localeStructure}.json`),
         addPath: path.join(process.cwd(), `${localePath}/${localeStructure}.missing.json`),
+      },
+    }
+  } else {
+    combinedConfig = {
+      ...combinedConfig,
+      backend: {
+        loadPath: `/${localePath}/${localeStructure}.json`,
+        addPath: `/${localePath}/${localeStructure}.missing.json`,
       },
     }
   }

--- a/src/config/create-config.js
+++ b/src/config/create-config.js
@@ -1,6 +1,8 @@
 import defaultConfig from 'config/default-config'
 import isNode from 'detect-node'
 
+const userDefinedBackend = userConfig => typeof userConfig.backend === 'object'
+
 export default (userConfig) => {
 
   let combinedConfig = {
@@ -18,6 +20,10 @@ export default (userConfig) => {
     .concat([combinedConfig.defaultLanguage])
   combinedConfig.ns = [combinedConfig.defaultNS]
 
+  if (!userDefinedBackend(userConfig)) {
+    combinedConfig.backend = {}
+  }
+
   const {
     localePath, localeStructure,
   } = combinedConfig
@@ -34,18 +40,25 @@ export default (userConfig) => {
       ...combinedConfig,
       preload: allLanguages,
       ns: getAllNamespaces(path.join(process.cwd(), `${localePath}/${defaultLanguage}`)),
-      backend: {
-        loadPath: path.join(process.cwd(), `${localePath}/${localeStructure}.json`),
-        addPath: path.join(process.cwd(), `${localePath}/${localeStructure}.missing.json`),
-      },
     }
+
+    let { loadPath, addPath } = combinedConfig.backend
+    if (typeof loadPath === 'undefined') {
+      loadPath = path.join(localePath, `${localeStructure}.json`)
+    }
+    combinedConfig.backend.loadPath = path.join(process.cwd(), loadPath)
+
+    if (typeof addPath === 'undefined') {
+      addPath = path.join(localePath, `${localeStructure}.missing.json`)
+    }
+    combinedConfig.backend.addPath = path.join(process.cwd(), addPath)
   } else {
-    combinedConfig = {
-      ...combinedConfig,
-      backend: {
-        loadPath: `/${localePath}/${localeStructure}.json`,
-        addPath: `/${localePath}/${localeStructure}.missing.json`,
-      },
+    if (typeof combinedConfig.backend.loadPath === 'undefined') {
+      combinedConfig.backend.loadPath = `/${localePath}/${localeStructure}.json`
+    }
+
+    if (typeof combinedConfig.backend.addPath === 'undefined') {
+      combinedConfig.backend.addPath = `/${localePath}/${localeStructure}.missing.json`
     }
   }
 

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -28,10 +28,6 @@ export default {
     order: ['cookie', 'header', 'querystring'],
     caches: ['cookie'],
   },
-  backend: {
-    loadPath: `/${LOCALE_PATH}/${LOCALE_STRUCTURE}.json`,
-    addPath: `/${LOCALE_PATH}/${LOCALE_STRUCTURE}.missing.json`,
-  },
   react: {
     wait: true,
   },


### PR DESCRIPTION
Currently, if the user defines their own loadPath and/or localeStructure, the server-side is properly configured, but the client-side does not change config.backend to reflect this change.

This change properly configures config.backend on the client to account for any changes in custom loadPath or localeStructure.

Related to #137.