### PR TITLE
refactor: Moving setting of config.backend to default configuration

### DIFF
--- a/__tests__/config/create-config.test.js
+++ b/__tests__/config/create-config.test.js
@@ -1,10 +1,11 @@
 /* eslint-env jest */
 
-import { userConfig, setUpTest, tearDownTest } from './test-helpers'
+import {
+  userConfigClientSide, userConfigServerSide, setUpTest, tearDownTest,
+} from './test-helpers'
 import { localeSubpathOptions } from '../../src/config/default-config'
 
 let mockIsNode
-jest.mock('detect-node', () => mockIsNode)
 
 describe('create configuration in non-production environment', () => {
   let createConfig
@@ -23,6 +24,7 @@ describe('create configuration in non-production environment', () => {
     mockIsNode = isNode
 
     jest.resetModules()
+    jest.mock('detect-node', () => mockIsNode)
 
     return require('../../src/config/create-config')
   }
@@ -74,7 +76,7 @@ describe('create configuration in non-production environment', () => {
         readdirSync: jest.fn().mockImplementation(() => ['universal', 'file1', 'file2']),
       }))
 
-      const config = createConfig(userConfig)
+      const config = createConfig(userConfigServerSide)
 
       expect(config.defaultLanguage).toEqual('de')
       expect(config.otherLanguages).toEqual(['fr', 'it'])
@@ -129,7 +131,7 @@ describe('create configuration in non-production environment', () => {
     })
 
     it('creates custom client-side non-production configuration', () => {
-      const config = createConfig(userConfig)
+      const config = createConfig(userConfigClientSide)
 
       expect(config.defaultLanguage).toEqual('de')
       expect(config.otherLanguages).toEqual(['fr', 'it'])
@@ -143,8 +145,8 @@ describe('create configuration in non-production environment', () => {
 
       expect(config.ns).toEqual(['universal'])
 
-      expect(config.backend.loadPath).toEqual('/static/locales/{{lng}}/{{ns}}.json')
-      expect(config.backend.addPath).toEqual('/static/locales/{{lng}}/{{ns}}.missing.json')
+      expect(config.backend.loadPath).toEqual('/static/translations/{{ns}}/{{lng}}.json')
+      expect(config.backend.addPath).toEqual('/static/translations/{{ns}}/{{lng}}.missing.json')
     })
   }
 
@@ -153,8 +155,8 @@ describe('create configuration in non-production environment', () => {
   // 2. isNode is truthy and process.browser is truthy
   describe('client-side (isNode is falsy)', () => {
     beforeEach(() => {
-      createConfig = mockIsNodeCreateConfig(false)
       delete process.browser
+      createConfig = mockIsNodeCreateConfig(false)
     })
 
     afterEach(() => {
@@ -166,8 +168,8 @@ describe('create configuration in non-production environment', () => {
 
   describe('client-side (isNode is truthy and process.browser is truthy)', () => {
     beforeEach(() => {
-      createConfig = mockIsNodeCreateConfig(true)
       process.browser = true
+      createConfig = mockIsNodeCreateConfig(true)
     })
 
     afterEach(() => {
@@ -183,7 +185,7 @@ describe('create configuration in non-production environment', () => {
       let userConfigDeNoFallback
 
       beforeEach(() => {
-        userConfigDeNoFallback = { ...userConfig, defaultLanguage: 'de' }
+        userConfigDeNoFallback = { ...userConfigClientSide, defaultLanguage: 'de' }
         delete userConfigDeNoFallback.fallbackLng
       })
 

--- a/__tests__/config/test-helpers.js
+++ b/__tests__/config/test-helpers.js
@@ -13,6 +13,22 @@ const userConfig = {
   localeSubpaths: localeSubpathOptions.FOREIGN,
 }
 
+const userConfigClientSide = {
+  ...userConfig,
+  backend: {
+    loadPath: '/static/translations/{{ns}}/{{lng}}.json',
+    addPath: '/static/translations/{{ns}}/{{lng}}.missing.json',
+  },
+}
+
+const userConfigServerSide = {
+  ...userConfig,
+  backend: {
+    loadPath: '/home/user/static/translations/{{ns}}/{{lng}}.json',
+    addPath: '/home/user/static/translations/{{ns}}/{{lng}}.missing.json',
+  },
+}
+
 const setUpTest = () => {
   const evalFunc = jest.spyOn(global, 'eval').mockImplementation(() => ({
     readdirSync: jest.fn().mockImplementation(() => ['common', 'file1', 'file2']),
@@ -35,7 +51,8 @@ const tearDownTest = (evalFunc, pwd) => {
 }
 
 export {
-  userConfig,
+  userConfigClientSide,
+  userConfigServerSide,
   setUpTest,
   tearDownTest,
 }

--- a/src/config/create-config.js
+++ b/src/config/create-config.js
@@ -1,6 +1,4 @@
-import isNode from 'detect-node'
-
-import defaultConfig from './default-config'
+import defaultConfig, { runningServerSide } from './default-config'
 
 const deepMergeObjects = ['detection']
 
@@ -35,23 +33,17 @@ export default (userConfig) => {
 
   combinedConfig.whitelist = combinedConfig.allLanguages
 
-  if (isNode && !process.browser) {
+  if (runningServerSide) {
     const fs = eval("require('fs')")
     const path = require('path')
 
     const getAllNamespaces = p => fs.readdirSync(p).map(file => file.replace('.json', ''))
-    const {
-      allLanguages, defaultLanguage, localePath, localeStructure,
-    } = combinedConfig
+    const { allLanguages, defaultLanguage, localePath } = combinedConfig
 
     combinedConfig = {
       ...combinedConfig,
       preload: allLanguages,
       ns: getAllNamespaces(path.join(process.cwd(), `${localePath}/${defaultLanguage}`)),
-      backend: {
-        loadPath: path.join(process.cwd(), `${localePath}/${localeStructure}.json`),
-        addPath: path.join(process.cwd(), `${localePath}/${localeStructure}.missing.json`),
-      },
     }
   }
 

--- a/src/config/create-config.js
+++ b/src/config/create-config.js
@@ -1,4 +1,4 @@
-import defaultConfig, { runningServerSide } from './default-config'
+import defaultConfig, { isServer } from './default-config'
 
 const deepMergeObjects = ['detection']
 
@@ -33,7 +33,7 @@ export default (userConfig) => {
 
   combinedConfig.whitelist = combinedConfig.allLanguages
 
-  if (runningServerSide) {
+  if (isServer) {
     const fs = eval("require('fs')")
     const path = require('path')
 

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -1,11 +1,11 @@
 import isNode from 'detect-node'
 
+export const isServer = isNode && !process.browser
 export const localeSubpathOptions = {
   ALL: 'all',
   FOREIGN: 'foreign',
   NONE: 'none',
 }
-export const runningServerSide = isNode && !process.browser
 
 const DEFAULT_LANGUAGE = 'en'
 const OTHER_LANGUAGES = []
@@ -45,7 +45,7 @@ const config = {
   errorStackTraceLimit: 0,
 }
 
-if (runningServerSide) {
+if (isServer) {
   const path = require('path')
 
   config.backend = {

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -1,8 +1,11 @@
+import isNode from 'detect-node'
+
 export const localeSubpathOptions = {
   ALL: 'all',
   FOREIGN: 'foreign',
   NONE: 'none',
 }
+export const runningServerSide = isNode && !process.browser
 
 const DEFAULT_LANGUAGE = 'en'
 const OTHER_LANGUAGES = []
@@ -11,7 +14,7 @@ const LOCALE_PATH = 'static/locales'
 const LOCALE_STRUCTURE = '{{lng}}/{{ns}}'
 const LOCALE_SUBPATHS = localeSubpathOptions.NONE
 
-export default {
+const config = {
   defaultLanguage: DEFAULT_LANGUAGE,
   otherLanguages: OTHER_LANGUAGES,
   load: 'currentOnly',
@@ -35,13 +38,25 @@ export default {
     order: ['cookie', 'header', 'querystring'],
     caches: ['cookie'],
   },
-  backend: {
-    loadPath: `/${LOCALE_PATH}/${LOCALE_STRUCTURE}.json`,
-    addPath: `/${LOCALE_PATH}/${LOCALE_STRUCTURE}.missing.json`,
-  },
   react: {
     wait: true,
   },
   strictMode: true,
   errorStackTraceLimit: 0,
 }
+
+if (runningServerSide) {
+  const path = require('path')
+
+  config.backend = {
+    loadPath: path.join(process.cwd(), `${LOCALE_PATH}/${LOCALE_STRUCTURE}.json`),
+    addPath: path.join(process.cwd(), `${LOCALE_PATH}/${LOCALE_STRUCTURE}.missing.json`),
+  }
+} else {
+  config.backend = {
+    loadPath: `/${LOCALE_PATH}/${LOCALE_STRUCTURE}.json`,
+    addPath: `/${LOCALE_PATH}/${LOCALE_STRUCTURE}.missing.json`,
+  }
+}
+
+export default config


### PR DESCRIPTION
In order to make it more explicit that users that define their own configurations will have to set their own `config.backend` options, moving the definition of `config.backend` to `default-config.js`.

Ref #140.