### PR TITLE
fix: Lng path corrector unknown lang

### DIFF
--- a/__tests__/config/create-config.test.js
+++ b/__tests__/config/create-config.test.js
@@ -95,6 +95,28 @@ describe('create configuration in non-production environment', () => {
       expect(config.backend.loadPath).toEqual('/home/user/static/translations/{{ns}}/{{lng}}.json')
       expect(config.backend.addPath).toEqual('/home/user/static/translations/{{ns}}/{{lng}}.missing.json')
     })
+
+    it('enforces that fallbackLng is an array in custom configuration', () => {
+      evalFunc.mockImplementation(() => ({
+        readdirSync: jest.fn().mockImplementation(() => ['universal', 'file1', 'file2']),
+      }))
+      const userConfigWithFallbackLngString = { ...userConfig, fallbackLng: 'en' }
+
+      const config = createConfig(userConfigWithFallbackLngString)
+
+      expect(config.fallbackLng).toEqual(['en'])
+    })
+
+    it('if fallbackLng is an array in custom configuration, leave it as such', () => {
+      evalFunc.mockImplementation(() => ({
+        readdirSync: jest.fn().mockImplementation(() => ['universal', 'file1', 'file2']),
+      }))
+      const userConfigWithFallbackLngString = { ...userConfig, fallbackLng: ['en'] }
+
+      const config = createConfig(userConfigWithFallbackLngString)
+
+      expect(config.fallbackLng).toEqual(['en'])
+    })
   })
 
   const runClientSideTests = () => {

--- a/__tests__/config/create-config.test.js
+++ b/__tests__/config/create-config.test.js
@@ -40,8 +40,10 @@ describe('create configuration in non-production environment', () => {
 
       expect(config.defaultLanguage).toEqual('en')
       expect(config.otherLanguages).toEqual([])
-      expect(config.fallbackLng).toBeNull()
-      expect(config.load).toEqual('languageOnly')
+      expect(config.allLanguages).toEqual(['en'])
+      expect(config.whitelist).toEqual(['en'])
+      expect(config.load).toEqual('currentOnly')
+      expect(config.fallbackLng).toEqual([])
       expect(config.localePath).toEqual('static/locales')
       expect(config.localeStructure).toEqual('{{lng}}/{{ns}}')
       expect(config.localeSubpaths).toEqual(false)
@@ -77,8 +79,10 @@ describe('create configuration in non-production environment', () => {
 
       expect(config.defaultLanguage).toEqual('de')
       expect(config.otherLanguages).toEqual(['fr', 'it'])
-      expect(config.fallbackLng).toEqual('it')
-      expect(config.load).toEqual('languageOnly')
+      expect(config.allLanguages).toEqual(['fr', 'it', 'de'])
+      expect(config.whitelist).toEqual(['fr', 'it', 'de'])
+      expect(config.load).toEqual('currentOnly')
+      expect(config.fallbackLng).toEqual(['it'])
       expect(config.localePath).toEqual('static/translations')
       expect(config.localeStructure).toEqual('{{ns}}/{{lng}}')
       expect(config.localeSubpaths).toEqual(true)
@@ -99,8 +103,10 @@ describe('create configuration in non-production environment', () => {
 
       expect(config.defaultLanguage).toEqual('en')
       expect(config.otherLanguages).toEqual([])
-      expect(config.fallbackLng).toBeNull()
-      expect(config.load).toEqual('languageOnly')
+      expect(config.allLanguages).toEqual(['en'])
+      expect(config.whitelist).toEqual(['en'])
+      expect(config.load).toEqual('currentOnly')
+      expect(config.fallbackLng).toEqual([])
       expect(config.localePath).toEqual('static/locales')
       expect(config.localeStructure).toEqual('{{lng}}/{{ns}}')
       expect(config.localeSubpaths).toEqual(false)
@@ -132,8 +138,10 @@ describe('create configuration in non-production environment', () => {
 
       expect(config.defaultLanguage).toEqual('de')
       expect(config.otherLanguages).toEqual(['fr', 'it'])
-      expect(config.fallbackLng).toEqual('it')
-      expect(config.load).toEqual('languageOnly')
+      expect(config.allLanguages).toEqual(['fr', 'it', 'de'])
+      expect(config.whitelist).toEqual(['fr', 'it', 'de'])
+      expect(config.load).toEqual('currentOnly')
+      expect(config.fallbackLng).toEqual(['it'])
       expect(config.localePath).toEqual('static/translations')
       expect(config.localeStructure).toEqual('{{ns}}/{{lng}}')
       expect(config.localeSubpaths).toEqual(true)
@@ -186,12 +194,12 @@ describe('create configuration in non-production environment', () => {
         delete userConfigDeNoFallback.fallbackLng
       })
 
-      it('fallbackLng === null in development', () => {
+      it('fallbackLng === [] in development', () => {
         createConfig = mockIsNodeCreateConfig(true)
 
         const config = createConfig(userConfigDeNoFallback)
 
-        expect(config.fallbackLng).toEqual(null)
+        expect(config.fallbackLng).toEqual([])
       })
 
       it('fallbackLng === user-specified default language in production', () => {
@@ -200,7 +208,7 @@ describe('create configuration in non-production environment', () => {
 
         const config = createConfig(userConfigDeNoFallback)
 
-        expect(config.fallbackLng).toEqual('de')
+        expect(config.fallbackLng).toEqual(['de'])
 
         delete process.env.NODE_ENV
       })

--- a/__tests__/utils/lng-from-req.test.js
+++ b/__tests__/utils/lng-from-req.test.js
@@ -54,4 +54,22 @@ describe('lngFromReq utility function', () => {
 
   })
 
+  it('returns fallback language if i18n.languages is not an array', () => {
+
+    req.i18n.languages = null
+    req.i18n.options.fallbackLng = ['es']
+    const language = lngFromReq(req)
+
+    expect(language).toBe('es')
+
+  })
+
+  it('returns default language if i18n.languages is not an array and no fallback language', () => {
+
+    req.i18n.languages = null
+    const language = lngFromReq(req)
+
+    expect(language).toBe('en')
+
+  })
 })

--- a/__tests__/utils/lng-from-req.test.js
+++ b/__tests__/utils/lng-from-req.test.js
@@ -11,7 +11,7 @@ describe('lngFromReq utility function', () => {
         options: {
           allLanguages: ['en', 'de'],
           defaultLanguage: 'en',
-          fallbackLng: null,
+          fallbackLng: [],
         },
       },
     }
@@ -38,7 +38,7 @@ describe('lngFromReq utility function', () => {
   it('returns fallback language if no others are available', () => {
 
     req.i18n.languages = ['nl']
-    req.i18n.options.fallbackLng = 'es'
+    req.i18n.options.fallbackLng = ['es']
     const language = lngFromReq(req)
 
     expect(language).toBe('es')

--- a/__tests__/utils/lng-path-corrector.test.js
+++ b/__tests__/utils/lng-path-corrector.test.js
@@ -23,11 +23,13 @@ describe('lngPathCorrector utility function', () => {
     }
   })
 
-  it('throws if allLanguages does not include current language', () => {
+  it('treats it like default language, if !allLanguages.includes(currentLanguage)', () => {
     config.allLanguages = ['de', 'fr']
+    currentRoute.asPath = '/de/foo'
+    currentRoute.query.query1 = 'value1'
 
-    expect(() => lngPathCorrector(config, i18n, currentRoute))
-      .toThrowError('Invalid configuration: Current language is not included in all languages array')
+    expect(lngPathCorrector(config, i18n, currentRoute))
+      .toEqual(['/foo', { query1: 'value1' }])
   })
 
   it('strips off the default language', () => {

--- a/src/config/create-config.js
+++ b/src/config/create-config.js
@@ -10,13 +10,17 @@ export default (userConfig) => {
 
   if (!userConfig.fallbackLng) {
     combinedConfig.fallbackLng = process.env.NODE_ENV === 'production'
-      ? combinedConfig.defaultLanguage
-      : null
+      ? [combinedConfig.defaultLanguage]
+      : []
+  } else if (typeof userConfig.fallbackLng === 'string') {
+    combinedConfig.fallbackLng = [userConfig.fallbackLng]
   }
 
   combinedConfig.allLanguages = combinedConfig.otherLanguages
     .concat([combinedConfig.defaultLanguage])
   combinedConfig.ns = [combinedConfig.defaultNS]
+  combinedConfig.whitelist = combinedConfig.allLanguages
+  combinedConfig.load = 'currentOnly'
 
   if (isNode && !process.browser) {
     const fs = eval("require('fs')")

--- a/src/config/create-config.js
+++ b/src/config/create-config.js
@@ -20,7 +20,6 @@ export default (userConfig) => {
     .concat([combinedConfig.defaultLanguage])
   combinedConfig.ns = [combinedConfig.defaultNS]
   combinedConfig.whitelist = combinedConfig.allLanguages
-  combinedConfig.load = 'currentOnly'
 
   if (isNode && !process.browser) {
     const fs = eval("require('fs')")

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -8,7 +8,7 @@ const LOCALE_SUBPATHS = false
 export default {
   defaultLanguage: DEFAULT_LANGUAGE,
   otherLanguages: OTHER_LANGUAGES,
-  load: 'languageOnly',
+  load: 'currentOnly',
   localePath: LOCALE_PATH,
   localeStructure: LOCALE_STRUCTURE,
   localeSubpaths: LOCALE_SUBPATHS,

--- a/src/utils/lng-from-req.js
+++ b/src/utils/lng-from-req.js
@@ -3,7 +3,7 @@ export default (req) => {
   const { allLanguages, defaultLanguage, fallbackLng } = req.i18n.options
 
   const language = req.i18n.languages.find(l => allLanguages.includes(l))
-    || fallbackLng
+    || fallbackLng[0]
     || defaultLanguage
 
   return language

--- a/src/utils/lng-from-req.js
+++ b/src/utils/lng-from-req.js
@@ -2,10 +2,9 @@ export default (req) => {
 
   const { allLanguages, defaultLanguage, fallbackLng } = req.i18n.options
 
-  const language = req.i18n.languages.find(l => allLanguages.includes(l))
-    || fallbackLng[0]
-    || defaultLanguage
+  if (Array.isArray(req.i18n.languages) && req.i18n.languages.some(l => allLanguages.includes(l))) {
+    return req.i18n.languages.find(l => allLanguages.includes(l))
+  }
 
-  return language
-
+  return fallbackLng[0] || defaultLanguage
 }

--- a/src/utils/lng-path-corrector.js
+++ b/src/utils/lng-path-corrector.js
@@ -3,10 +3,6 @@ export default (config, i18n, currentRoute, currentLanguage = i18n.languages[0])
   const { defaultLanguage, allLanguages } = config
   const { asPath, query } = currentRoute
 
-  if (!allLanguages.includes(currentLanguage)) {
-    throw new Error('Invalid configuration: Current language is not included in all languages array')
-  }
-
   let as = asPath
 
   for (const lng of allLanguages) {
@@ -16,9 +12,9 @@ export default (config, i18n, currentRoute, currentLanguage = i18n.languages[0])
     }
   }
 
-  if (currentLanguage !== defaultLanguage) {
-    return [`/${currentLanguage}${as}`, { ...query, lng: currentLanguage }]
+  if (currentLanguage === defaultLanguage || !allLanguages.includes(currentLanguage)) {
+    return [as, query]
   }
 
-  return [as, query]
+  return [`/${currentLanguage}${as}`, { ...query, lng: currentLanguage }]
 }


### PR DESCRIPTION
* Ensure that `fallbackLng` is an array
* `config.whitelist = config.allLanguages`
* `config.load = 'currentOnly'`
* Ensure that `req.i18n.languages` is an array in `lng-from-req` before we proceed with the `find` operation -- if it is not, use `defaultLanguage`

See [comment](https://github.com/isaachinman/next-i18next/issues/137#issuecomment-459844339) in #137.
