### PR TITLE
refactor: Babel setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,27 +1,61 @@
 {
-  "presets": [
-    [
-      "@babel/env",
-      {
-        "targets": {
-          "node": "current"
-        }
-      }
-    ],
-    ["@babel/preset-react"]
-  ],
-  "plugins": [
-    [
-      "module-resolver",
-      {
-        "root": ["./src"]
-      }
-    ],
-    [
-      "add-module-exports",
-      {
-        "addDefaultProperty": true
-      }
-    ]
-  ]
+  "env": {
+    "es": {
+      "presets": [
+        [
+          "@babel/env",
+          {
+            "modules": false,
+            "targets": {
+              "node": "current"
+            }
+          }
+        ],
+        ["@babel/preset-react"]
+      ]
+    },
+    "cjs": {
+      "presets": [
+        [
+          "@babel/env",
+          {
+            "targets": {
+              "node": "current"
+            }
+          }
+        ],
+        ["@babel/preset-react"]
+      ],
+      "plugins": [
+        [
+          "add-module-exports",
+          {
+            "addDefaultProperty": true
+          }
+        ]
+      ]
+    },
+    "test": {
+      "presets": [
+        [
+          "@babel/env",
+          {
+            "targets": {
+              "node": "current"
+            },
+            "modules": "commonjs"
+          }
+        ],
+        ["@babel/preset-react"]
+      ],
+      "plugins": [
+        [
+          "add-module-exports",
+          {
+            "addDefaultProperty": true
+          }
+        ]
+      ]
+    },
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ out
 
 # Testing
 coverage/
+
+# npm
+package-lock.json

--- a/__tests__/config/create-config.test.js
+++ b/__tests__/config/create-config.test.js
@@ -23,7 +23,7 @@ describe('create configuration in non-production environment', () => {
 
     jest.resetModules()
 
-    return require('config/create-config')
+    return require('../../src/config/create-config')
   }
 
   describe('server-side', () => {

--- a/__tests__/hocs/with-config.test.js
+++ b/__tests__/hocs/with-config.test.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 
-import { withConfig } from 'hocs'
+import { withConfig } from '../../src/hocs'
 
 describe('withConfig HoC', () => {
   let config

--- a/__tests__/middlewares/next-i18next-middleware.test.js
+++ b/__tests__/middlewares/next-i18next-middleware.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import i18nextMiddleware from 'i18next-express-middleware'
-import { forceTrailingSlash, lngPathDetector } from 'utils'
+import { forceTrailingSlash, lngPathDetector } from '../../src/utils'
 import testI18NextConfig from '../test-i18next-config'
 
 import nextI18nextMiddleware from '../../src/middlewares/next-i18next-middleware'
@@ -10,7 +10,7 @@ jest.mock('i18next-express-middleware', () => ({
   handle: jest.fn(() => jest.fn()),
 }))
 
-jest.mock('utils', () => ({
+jest.mock('../../src/utils', () => ({
   forceTrailingSlash: jest.fn(),
   lngPathDetector: jest.fn(),
 }))

--- a/__tests__/test-i18next-config.js
+++ b/__tests__/test-i18next-config.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import defaultConfig from 'config/default-config'
+import defaultConfig from '../src/config/default-config'
 
 export default {
   changeLanguage: jest.fn(),

--- a/__tests__/utils/console-message.test.js
+++ b/__tests__/utils/console-message.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-env jest */
 
-import { consoleMessage as _consoleMessage } from 'utils'
+import { consoleMessage as _consoleMessage } from '../../src/utils'
 
 const consoleMessage = _consoleMessage.bind({
   config: {

--- a/examples/simple/i18n.js
+++ b/examples/simple/i18n.js
@@ -1,3 +1,3 @@
-const NextI18Next = require('next-i18next')
+const NextI18Next = require('next-i18next').default
 
 module.exports = new NextI18Next({ otherLanguages: ['de'] })

--- a/middleware.js
+++ b/middleware.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/middlewares/next-i18next-middleware')
+module.exports = require('./dist/commonjs/middlewares/next-i18next-middleware')

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "next-i18next",
   "version": "0.27.0",
-  "main": "dist/index.js",
   "repository": "git@github.com:isaachinman/next-i18next.git",
   "author": "Isaac Hinman <isaac@isaachinman.com>",
+  "main": "dist/commonjs/index.js",
+  "jsnext:main": "dist/es/index.js",
+  "module": "dist/es/index.js",
   "license": "MIT",
   "engines": {
     "node": ">=8"
@@ -20,10 +22,12 @@
     "locale"
   ],
   "scripts": {
-    "start": "babel-node ./src/index.js",
     "lint": "eslint src examples __tests__",
     "lint:fix": "eslint src examples __tests__ --fix",
-    "build": "babel src --out-dir dist",
+    "clean": "rm -rf dist && mkdir dist",
+    "build:es": "BABEL_ENV=es babel src --out-dir dist/es",
+    "build:cjs": "BABEL_ENV=cjs babel src --out-dir dist/commonjs",
+    "build": "yarn clean && yarn build:cjs && yarn build:es",
     "prepublishOnly": "yarn build",
     "run-example": "yarn build && cd examples/simple && rm -rf node_modules && yarn && yarn dev",
     "run-example:prod": "yarn build && cd examples/simple && rm -rf node_modules && yarn && yarn build && yarn start",
@@ -40,7 +44,6 @@
   "devDependencies": {
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.1.6",
-    "@babel/node": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
@@ -48,7 +51,6 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "babel-plugin-add-module-exports": "^1.0.0",
-    "babel-plugin-module-resolver": "^3.1.1",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types'
 import NextLink from 'next/link'
 import { withNamespaces } from 'react-i18next'
 import { format as formatUrl, parse as parseUrl } from 'url'
-import { lngPathCorrector } from 'utils'
+import { lngPathCorrector } from '../utils'
 
 const localeSubpathRequired = (nextI18NextConfig, lng) => {
   const { defaultLanguage, localeSubpaths } = nextI18NextConfig.config

--- a/src/config/create-config.js
+++ b/src/config/create-config.js
@@ -1,5 +1,6 @@
-import defaultConfig from 'config/default-config'
 import isNode from 'detect-node'
+
+import defaultConfig from './default-config'
 
 export default (userConfig) => {
 

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import { withRouter } from 'next/router'
 
-import { I18nextProvider } from 'react-i18next'
-import { lngFromReq, lngPathCorrector } from 'utils'
-import { NextStaticProvider } from 'components'
-
 import hoistNonReactStatics from 'hoist-non-react-statics'
+import { I18nextProvider } from 'react-i18next'
+
+import { lngFromReq, lngPathCorrector } from '../utils'
+import { NextStaticProvider } from '../components'
 
 export default function (WrappedComponent) {
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
-import createConfig from 'config/create-config'
-import createI18NextClient from 'create-i18next-client'
-
-import { appWithTranslation, withConfig } from 'hocs'
-import { consoleMessage } from 'utils'
-import { Link, Trans } from 'components'
 import { withNamespaces } from 'react-i18next'
+
+import createConfig from './config/create-config'
+import createI18NextClient from './create-i18next-client'
+
+import { appWithTranslation, withConfig } from './hocs'
+import { consoleMessage } from './utils'
+import { Link, Trans } from './components'
 
 export default class NextI18Next {
 

--- a/src/middlewares/next-i18next-middleware.js
+++ b/src/middlewares/next-i18next-middleware.js
@@ -1,7 +1,8 @@
 import i18nextMiddleware from 'i18next-express-middleware'
-import { forceTrailingSlash, lngPathDetector } from 'utils'
 import { parse } from 'url'
 import pathMatch from 'path-match'
+
+import { forceTrailingSlash, lngPathDetector } from '../utils'
 
 const route = pathMatch()
 

--- a/src/utils/force-trailing-slash.js
+++ b/src/utils/force-trailing-slash.js
@@ -1,5 +1,5 @@
 import { parse } from 'url'
-import { redirectWithoutCache } from 'utils'
+import redirectWithoutCache from './redirect-without-cache'
 
 export default (req, res, lng) => {
   const { pathname, search } = parse(req.url)

--- a/src/utils/lng-path-detector.js
+++ b/src/utils/lng-path-detector.js
@@ -1,4 +1,5 @@
-import { lngFromReq, redirectWithoutCache } from 'utils'
+import lngFromReq from './lng-from-req'
+import redirectWithoutCache from './redirect-without-cache'
 
 export default (req, res) => {
   if (req.i18n) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,19 +288,6 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/node@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/node/-/node-7.0.0.tgz#20e55bb0e015700a0f6ff281c712de7619ad56f4"
-  integrity sha512-mKbN8Bb1TzH9YnKMWMhBRX+o5MVJHtUSalNcsiGa4FRgVfY7ozqkbttuIDWqeXxZ3rwI9ZqmCUr9XsPV2VYlSw==
-  dependencies:
-    "@babel/polyfill" "^7.0.0"
-    "@babel/register" "^7.0.0"
-    commander "^2.8.1"
-    fs-readdir-recursive "^1.0.0"
-    lodash "^4.17.10"
-    output-file-sync "^2.0.0"
-    v8flags "^3.1.1"
-
 "@babel/parser@^7.0.0", "@babel/parser@^7.2.2", "@babel/parser@^7.2.3":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.1.tgz#8f4ffd45f779e6132780835ffa7a215fa0b2d181"
@@ -785,14 +772,6 @@
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
 
-"@babel/polyfill@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.0.0.tgz#c8ff65c9ec3be6a1ba10113ebd40e8750fb90bff"
-  integrity sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==
-  dependencies:
-    core-js "^2.5.7"
-    regenerator-runtime "^0.11.1"
-
 "@babel/preset-env@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.0.0.tgz#f450f200c14e713f98cb14d113bf0c2cfbb89ca9"
@@ -897,19 +876,6 @@
     "@babel/plugin-transform-react-jsx" "^7.0.0"
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
-
-"@babel/register@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.0.0.tgz#fa634bae1bfa429f60615b754fc1f1d745edd827"
-  integrity sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==
-  dependencies:
-    core-js "^2.5.7"
-    find-cache-dir "^1.0.0"
-    home-or-tmp "^3.0.0"
-    lodash "^4.17.10"
-    mkdirp "^0.5.1"
-    pirates "^4.0.0"
-    source-map-support "^0.5.9"
 
 "@babel/runtime-corejs2@7.0.0":
   version "7.0.0"
@@ -1702,17 +1668,6 @@ babel-plugin-jest-hoist@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
   integrity sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=
-
-babel-plugin-module-resolver@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.1.1.tgz#881cf67e3d4b8400d5eaaefc1be44d2dc1fe404f"
-  integrity sha512-1Q77Al4ydp6nYApJ7sQ2fmgz30WuQgJZegIYuyOdbdpxenB/bSezQ3hDPsumIXGlUS4vUIv+EwFjzzXZNWtARw==
-  dependencies:
-    find-babel-config "^1.1.0"
-    glob "^7.1.2"
-    pkg-up "^2.0.0"
-    reselect "^3.0.1"
-    resolve "^1.4.0"
 
 babel-plugin-react-require@3.0.0:
   version "3.0.0"
@@ -3523,14 +3478,6 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-find-babel-config@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
-  integrity sha1-rMAQQ6Z0n+w0Qpvmtk9ULrtdY1U=
-  dependencies:
-    json5 "^0.5.1"
-    path-exists "^3.0.0"
-
 find-cache-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
@@ -3686,7 +3633,7 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.2.1"
 
-fs-readdir-recursive@^1.0.0, fs-readdir-recursive@^1.1.0:
+fs-readdir-recursive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
   integrity sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==
@@ -4030,12 +3977,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-home-or-tmp@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-3.0.0.tgz#57a8fe24cf33cdd524860a15821ddc25c86671fb"
-  integrity sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=
-
-homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
+homedir-polyfill@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   integrity sha1-TCu8inWJmP7r9e1oWA921GdotLw=
@@ -5951,11 +5893,6 @@ node-libs-browser@^2.0.0:
     util "^0.11.0"
     vm-browserify "0.0.4"
 
-node-modules-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
-  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
-
 node-notifier@^5.2.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.3.0.tgz#c77a4a7b84038733d5fb351aafd8a268bfe19a01"
@@ -6499,13 +6436,6 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.0.tgz#850b18781b4ac6ec58a43c9ed9ec5fe6796addbd"
-  integrity sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==
-  dependencies:
-    node-modules-regexp "^1.0.0"
-
 pkg-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
@@ -6526,13 +6456,6 @@ pkg-dir@^3.0.0:
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
-
-pkg-up@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
-  integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
-  dependencies:
-    find-up "^2.1.0"
 
 please-upgrade-node@^3.1.1:
   version "3.1.1"
@@ -6982,7 +6905,7 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
+regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
@@ -7128,11 +7051,6 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
-reselect@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
-  integrity sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=
-
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -7175,7 +7093,7 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
+resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
@@ -7545,7 +7463,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6, source-map-support@^0.5.9:
+source-map-support@^0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
@@ -8263,13 +8181,6 @@ uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
-
-v8flags@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.1.tgz#42259a1461c08397e37fe1d4f1cfb59cad85a053"
-  integrity sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==
-  dependencies:
-    homedir-polyfill "^1.0.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
After some further thought, I don't think `rollup` or `webpack` are truly necessary for a lib like this.

The primary consumer of this library are NextJs applications, which will have their own build process to compile both server and client code.

End users can modify their own Babel configuration to target whatever browsers they'd like.

In the end, we should primarily export `es` modules, but it's also useful to export `cjs` for those people who don't want to set up `es` modules for their NodeJs processes.