### PR TITLE
feat: Enable default language subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ myapp.com/de/
 myapp.com/es/
 ```
 
+If you want to enable default locale subpath, pass this option into the `NextI18Next` constructor:
+```jsx
+new NextI18Next({ localeSubpaths: true, defaultLocaleSubpath: true })
+```
+
+ And we will get:
+```
+myapp.com/en/
+myapp.com/fr/
+myapp.com/de/
+myapp.com/es/
+```
+
 The main "gotcha" with locale subpaths is routing. We want to be able to route to "naked" routes, and not have to worry about the locale subpath part of the route:
 
 ```jsx
@@ -192,6 +205,7 @@ server.get('*', (req, res) => handle(req, res))
 | `localePath` | `'static/locales'`  |
 | `localeStructure` | `'{{lng}}/{{ns}}'`  |
 | `localeSubpaths` | `false`  |
+| `defaultLocaleSubpath` | `false`  |
 | `serverLanguageDetection` | `true`  |
 | `use` (for plugins) | `[]`  |
 | `customDetectors` | `[]`  |

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ myapp.com/de/
 myapp.com/es/
 ```
 
-If you want to enable default locale subpath, pass this option into the `NextI18Next` constructor:
+If you also want to enable locale subpaths for the default locale, pass the `defaultLocaleSubpath` option into the `NextI18Next` constructor:
 ```jsx
 new NextI18Next({ localeSubpaths: true, defaultLocaleSubpath: true })
 ```

--- a/__tests__/utils/lng-path-corrector.test.js
+++ b/__tests__/utils/lng-path-corrector.test.js
@@ -177,6 +177,21 @@ describe('lngPathCorrector utility function', () => {
       expect(format(result.href)).toEqual('/somewhere/else?option1=value1#hash1')
     })
 
+    it('does not removes default language from as when defaultLocaleSubpath is true', () => {
+      currentRoute.as = '/en/foo'
+      currentRoute.href = '/somewhere/else?option1=value1#hash1'
+      config.defaultLocaleSubpath = true
+
+      const result = lngPathCorrector(config, currentRoute, 'en')
+      expect(result.as).toEqual('/en/foo')
+      expect(result.href).toEqual(expect.objectContaining({
+        pathname: '/somewhere/else',
+        hash: '#hash1',
+        query: { option1: 'value1', lng: 'en' },
+      }))
+      expect(format(result.href)).toEqual('/somewhere/else?option1=value1&lng=en#hash1')
+    })
+
     it('adds non-default language to as and href.query', () => {
       currentRoute.as = '/foo'
       currentRoute.href = '/somewhere/else?option1=value1#hash1'

--- a/__tests__/utils/lng-path-corrector.test.js
+++ b/__tests__/utils/lng-path-corrector.test.js
@@ -177,7 +177,7 @@ describe('lngPathCorrector utility function', () => {
       expect(format(result.href)).toEqual('/somewhere/else?option1=value1#hash1')
     })
 
-    it('does not removes default language from as when defaultLocaleSubpath is true', () => {
+    it('does not remove default language from as when defaultLocaleSubpath is true', () => {
       currentRoute.as = '/en/foo'
       currentRoute.href = '/somewhere/else?option1=value1#hash1'
       config.defaultLocaleSubpath = true

--- a/__tests__/utils/lng-path-detector.test.js
+++ b/__tests__/utils/lng-path-detector.test.js
@@ -67,6 +67,6 @@ describe('lngPathDetector utility function', () => {
 
     lngPathDetector(req, res, true)
 
-    expect(res.redirect).not.toBeCalledWith()
+    expect(res.redirect).not.toBeCalled()
   })
 })

--- a/__tests__/utils/lng-path-detector.test.js
+++ b/__tests__/utils/lng-path-detector.test.js
@@ -60,7 +60,7 @@ describe('lngPathDetector utility function', () => {
     expect(res.redirect).toBeCalledWith(302, '/foo')
   })
 
-  it('does not strips language off url if language is languages[0] with defaultLocaleSubpath to true ', () => {
+  it('does not redirect if language is languages[0] and defaultLocaleSubpath is true ', () => {
     req.i18n.languages = ['en', 'de']
     req.i18n.options.defaultLocaleSubpath = true
     req.url = '/en/foo'

--- a/__tests__/utils/lng-path-detector.test.js
+++ b/__tests__/utils/lng-path-detector.test.js
@@ -59,4 +59,14 @@ describe('lngPathDetector utility function', () => {
 
     expect(res.redirect).toBeCalledWith(302, '/foo')
   })
+
+  it('does not strips language off url if language is languages[0] with defaultLocaleSubpath to true ', () => {
+    req.i18n.languages = ['en', 'de']
+    req.i18n.options.defaultLocaleSubpath = true
+    req.url = '/en/foo'
+
+    lngPathDetector(req, res, true)
+
+    expect(res.redirect).not.toBeCalledWith()
+  })
 })

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -4,6 +4,7 @@ const DEFAULT_NAMESPACE = 'common'
 const LOCALE_PATH = 'static/locales'
 const LOCALE_STRUCTURE = '{{lng}}/{{ns}}'
 const LOCALE_SUBPATHS = false
+const DEFAULT_LOCALE_SUBPATH = false
 
 export default {
   defaultLanguage: DEFAULT_LANGUAGE,
@@ -12,6 +13,7 @@ export default {
   localePath: LOCALE_PATH,
   localeStructure: LOCALE_STRUCTURE,
   localeSubpaths: LOCALE_SUBPATHS,
+  defaultLocaleSubpath: DEFAULT_LOCALE_SUBPATH,
   ns: [DEFAULT_NAMESPACE],
   use: [],
   defaultNS: DEFAULT_NAMESPACE,

--- a/src/utils/lng-path-corrector.js
+++ b/src/utils/lng-path-corrector.js
@@ -33,7 +33,8 @@ const parseHref = (originalHref) => {
 
 export default (config, currentRoute, currentLanguage) => {
   const { defaultLanguage, allLanguages, defaultLocaleSubpath } = config
-  const { as: originalAs, href: originalHref } = currentRoute
+   const { as: originalAs, href: originalHref } = currentRoute
+
   if (!allLanguages.includes(currentLanguage)) {
     throw new Error('Invalid configuration: Current language is not included in all languages array')
   }

--- a/src/utils/lng-path-corrector.js
+++ b/src/utils/lng-path-corrector.js
@@ -33,7 +33,7 @@ const parseHref = (originalHref) => {
 
 export default (config, currentRoute, currentLanguage) => {
   const { defaultLanguage, allLanguages, defaultLocaleSubpath } = config
-   const { as: originalAs, href: originalHref } = currentRoute
+  const { as: originalAs, href: originalHref } = currentRoute
 
   if (!allLanguages.includes(currentLanguage)) {
     throw new Error('Invalid configuration: Current language is not included in all languages array')

--- a/src/utils/lng-path-corrector.js
+++ b/src/utils/lng-path-corrector.js
@@ -32,9 +32,8 @@ const parseHref = (originalHref) => {
 }
 
 export default (config, currentRoute, currentLanguage) => {
-  const { defaultLanguage, allLanguages } = config
+  const { defaultLanguage, allLanguages, defaultLocaleSubpath } = config
   const { as: originalAs, href: originalHref } = currentRoute
-
   if (!allLanguages.includes(currentLanguage)) {
     throw new Error('Invalid configuration: Current language is not included in all languages array')
   }
@@ -53,7 +52,7 @@ export default (config, currentRoute, currentLanguage) => {
     }
   }
 
-  if (currentLanguage !== defaultLanguage) {
+  if (currentLanguage !== defaultLanguage || defaultLocaleSubpath) {
     as = `/${currentLanguage}${as}`
     href.query.lng = currentLanguage
   }

--- a/src/utils/lng-path-detector.js
+++ b/src/utils/lng-path-detector.js
@@ -4,7 +4,7 @@ import redirectWithoutCache from './redirect-without-cache'
 export default (req, res) => {
   if (req.i18n) {
     const language = lngFromReq(req)
-    const { allLanguages, defaultLanguage } = req.i18n.options
+    const { allLanguages, defaultLanguage, defaultLocaleSubpath } = req.i18n.options
     let languageChanged = false
     /*
       If a user has hit a subpath which does not
@@ -35,7 +35,7 @@ export default (req, res) => {
       If a user has a default language prefix
       in their URL, strip it.
     */
-    if (language === defaultLanguage && req.url.startsWith(`/${defaultLanguage}/`)) {
+    if (language === defaultLanguage && req.url.startsWith(`/${defaultLanguage}/`) && !defaultLocaleSubpath) {
       redirectWithoutCache(res, req.url.replace(`/${defaultLanguage}/`, '/'))
     }
   }

--- a/src/utils/locale-subpath-required.js
+++ b/src/utils/locale-subpath-required.js
@@ -1,4 +1,5 @@
 export default (nextI18NextConfig, lng) => {
   const { defaultLanguage, localeSubpaths, defaultLocaleSubpath } = nextI18NextConfig.config
+
   return localeSubpaths && lng && (lng !== defaultLanguage || defaultLocaleSubpath)
 }

--- a/src/utils/locale-subpath-required.js
+++ b/src/utils/locale-subpath-required.js
@@ -1,5 +1,4 @@
 export default (nextI18NextConfig, lng) => {
-  const { defaultLanguage, localeSubpaths } = nextI18NextConfig.config
-
-  return localeSubpaths && lng && lng !== defaultLanguage
+  const { defaultLanguage, localeSubpaths, defaultLocaleSubpath } = nextI18NextConfig.config
+  return localeSubpaths && lng && (lng !== defaultLanguage || defaultLocaleSubpath)
 }


### PR DESCRIPTION
Add of variable **defaultLocaleSubpath** to let the user choose if he wants his default language in URL
Example: If the default language is **EN**, the url will be **/en/someUrl**

From https://github.com/isaachinman/next-i18next/pull/24