### PR TITLE
refactor: Change locale subpaths to a string enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ myapp.com/de/     ---> Homepage in German
 This functionality is not enabled by default, and must be passed as an option into the `NextI18Next` constructor:
 
 ```jsx
-new NextI18Next({ localeSubpaths: true })
+new NextI18Next({ localeSubpaths: 'foreign' })
 ```
 
 Now, all your page routes will be duplicated across all your non-default language subpaths. If our `static/locales` folder included `fr`, `de`, and `es` translation directories, we will automatically get:
@@ -120,12 +120,12 @@ myapp.com/de/
 myapp.com/es/
 ```
 
-If you also want to enable locale subpaths for the default locale, pass the `defaultLocaleSubpath` option into the `NextI18Next` constructor:
+If you also want to enable locale subpaths for the default locale, set `localeSubpaths` to `all`:
 ```jsx
-new NextI18Next({ localeSubpaths: true, defaultLocaleSubpath: true })
+new NextI18Next({ localeSubpaths: 'all' })
 ```
 
- And we will get:
+We'll now get:
 ```
 myapp.com/en/
 myapp.com/fr/
@@ -204,8 +204,7 @@ server.get('*', (req, res) => handle(req, res))
 | `otherLanguages` (required) | `[]`  |
 | `localePath` | `'static/locales'`  |
 | `localeStructure` | `'{{lng}}/{{ns}}'`  |
-| `localeSubpaths` | `false`  |
-| `defaultLocaleSubpath` | `false`  |
+| `localeSubpaths` | `'none'`  |
 | `serverLanguageDetection` | `true`  |
 | `use` (for plugins) | `[]`  |
 | `customDetectors` | `[]`  |

--- a/__tests__/components/Link.test.js
+++ b/__tests__/components/Link.test.js
@@ -4,6 +4,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 
 import Link from '../../src/components/Link'
+import { localeSubpathOptions } from '../../src/config/default-config'
 
 jest.mock('next/link')
 jest.mock('react-i18next', () => ({
@@ -21,7 +22,7 @@ describe('Link component', () => {
         config: {
           allLanguages: ['en', 'de'],
           defaultLanguage: 'en',
-          localeSubpaths: false,
+          localeSubpaths: localeSubpathOptions.NONE,
         },
       },
     }
@@ -31,7 +32,7 @@ describe('Link component', () => {
     <Link {...props} {...otherProps}>click here</Link>,
   ).find('Link').at(1)
 
-  it('renders without lang if localeSubpaths === false', () => {
+  it(`renders without lang if localeSubpaths is "${localeSubpathOptions.NONE}"`, () => {
     // without 'as' prop
     let component = createLinkComponent()
 
@@ -47,7 +48,7 @@ describe('Link component', () => {
   })
 
   it('renders without lang if props.lng is undefined', () => {
-    props.nextI18NextConfig.config.localeSubpaths = true
+    props.nextI18NextConfig.config.localeSubpaths = localeSubpathOptions.FOREIGN
     props.lng = undefined
 
     // without 'as' prop
@@ -65,7 +66,7 @@ describe('Link component', () => {
   })
 
   it('renders without lang if props.lng === defaultLanguage', () => {
-    props.nextI18NextConfig.config.localeSubpaths = true
+    props.nextI18NextConfig.config.localeSubpaths = localeSubpathOptions.FOREIGN
     props.nextI18NextConfig.config.defaultLanguage = 'en'
     props.lng = 'en'
 
@@ -84,7 +85,7 @@ describe('Link component', () => {
   })
 
   it('renders with lang', () => {
-    props.nextI18NextConfig.config.localeSubpaths = true
+    props.nextI18NextConfig.config.localeSubpaths = localeSubpathOptions.FOREIGN
     props.nextI18NextConfig.config.defaultLanguage = 'en'
 
     // without 'as' prop -- no query parameters
@@ -125,9 +126,9 @@ describe('Link component', () => {
         }
       })
 
-      describe('localeSubpaths === false', () => {
+      describe(`localeSubpaths = "${localeSubpathOptions.NONE}"`, () => {
         beforeEach(() => {
-          props.nextI18NextConfig.config.localeSubpaths = false
+          props.nextI18NextConfig.config.localeSubpaths = localeSubpathOptions.NONE
         })
 
         it('renders without lang', () => {
@@ -147,9 +148,9 @@ describe('Link component', () => {
         })
       })
 
-      describe('localeSubpaths === true', () => {
+      describe(`localeSubpaths = "${localeSubpathOptions.FOREIGN}"`, () => {
         beforeEach(() => {
-          props.nextI18NextConfig.config.localeSubpaths = true
+          props.nextI18NextConfig.config.localeSubpaths = localeSubpathOptions.FOREIGN
         })
 
         beforeEach(() => {

--- a/__tests__/config/create-config.test.js
+++ b/__tests__/config/create-config.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
 import { userConfig, setUpTest, tearDownTest } from './test-helpers'
+import { localeSubpathOptions } from '../../src/config/default-config'
 
 let mockIsNode
 jest.mock('detect-node', () => mockIsNode)
@@ -44,7 +45,7 @@ describe('create configuration in non-production environment', () => {
       expect(config.load).toEqual('currentOnly')
       expect(config.localePath).toEqual('static/locales')
       expect(config.localeStructure).toEqual('{{lng}}/{{ns}}')
-      expect(config.localeSubpaths).toEqual(false)
+      expect(config.localeSubpaths).toEqual(localeSubpathOptions.NONE)
       expect(config.use).toEqual([])
       expect(config.defaultNS).toEqual('common')
 
@@ -81,7 +82,7 @@ describe('create configuration in non-production environment', () => {
       expect(config.load).toEqual('currentOnly')
       expect(config.localePath).toEqual('static/translations')
       expect(config.localeStructure).toEqual('{{ns}}/{{lng}}')
-      expect(config.localeSubpaths).toEqual(true)
+      expect(config.localeSubpaths).toEqual(localeSubpathOptions.FOREIGN)
       expect(config.defaultNS).toEqual('universal')
       expect(config.browserLanguageDetection).toEqual(false)
       expect(config.preload).toEqual(['fr', 'it', 'de'])
@@ -103,7 +104,7 @@ describe('create configuration in non-production environment', () => {
       expect(config.load).toEqual('currentOnly')
       expect(config.localePath).toEqual('static/locales')
       expect(config.localeStructure).toEqual('{{lng}}/{{ns}}')
-      expect(config.localeSubpaths).toEqual(false)
+      expect(config.localeSubpaths).toEqual(localeSubpathOptions.NONE)
       expect(config.use).toEqual([])
       expect(config.defaultNS).toEqual('common')
 
@@ -136,7 +137,7 @@ describe('create configuration in non-production environment', () => {
       expect(config.load).toEqual('currentOnly')
       expect(config.localePath).toEqual('static/translations')
       expect(config.localeStructure).toEqual('{{ns}}/{{lng}}')
-      expect(config.localeSubpaths).toEqual(true)
+      expect(config.localeSubpaths).toEqual(localeSubpathOptions.FOREIGN)
       expect(config.defaultNS).toEqual('universal')
       expect(config.browserLanguageDetection).toEqual(false)
 

--- a/__tests__/config/test-helpers.js
+++ b/__tests__/config/test-helpers.js
@@ -1,3 +1,5 @@
+import { localeSubpathOptions } from '../../src/config/default-config'
+
 /* eslint-env jest */
 
 const userConfig = {
@@ -8,7 +10,7 @@ const userConfig = {
   otherLanguages: ['fr', 'it'],
   localePath: 'static/translations',
   localeStructure: '{{ns}}/{{lng}}',
-  localeSubpaths: true,
+  localeSubpaths: localeSubpathOptions.FOREIGN,
 }
 
 const setUpTest = () => {

--- a/__tests__/hocs/with-config.test.js
+++ b/__tests__/hocs/with-config.test.js
@@ -4,6 +4,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 
 import { withConfig } from '../../src/hocs'
+import { localeSubpathOptions } from '../../src/config/default-config'
 
 describe('withConfig HoC', () => {
   let config
@@ -11,7 +12,7 @@ describe('withConfig HoC', () => {
   let WrappedComponent
 
   beforeEach(() => {
-    config = { localeSubpaths: true }
+    config = { localeSubpaths: localeSubpathOptions.FOREIGN }
     props = {}
     WrappedComponent = () => <div />
   })
@@ -20,7 +21,7 @@ describe('withConfig HoC', () => {
     const Component = withConfig(WrappedComponent, config)
 
     expect(mount(<Component />).find('WrappedComponent').prop('nextI18NextConfig'))
-      .toEqual({ localeSubpaths: true })
+      .toEqual({ localeSubpaths: localeSubpathOptions.FOREIGN })
   })
 
   it('passes other props into wrapped component', () => {
@@ -29,7 +30,7 @@ describe('withConfig HoC', () => {
     const Component = withConfig(WrappedComponent, config)
 
     const wrappedComponent = mount(<Component {...props} />).find('WrappedComponent')
-    expect(wrappedComponent.prop('nextI18NextConfig')).toEqual({ localeSubpaths: true })
+    expect(wrappedComponent.prop('nextI18NextConfig')).toEqual({ localeSubpaths: localeSubpathOptions.FOREIGN })
     expect(wrappedComponent.prop('prop')).toEqual('value')
   })
 

--- a/__tests__/middlewares/next-i18next-middleware.test.js
+++ b/__tests__/middlewares/next-i18next-middleware.test.js
@@ -5,6 +5,7 @@ import { forceTrailingSlash, lngPathDetector } from '../../src/utils'
 import testI18NextConfig from '../test-i18next-config'
 
 import nextI18nextMiddleware from '../../src/middlewares/next-i18next-middleware'
+import { localeSubpathOptions } from '../../src/config/default-config'
 
 jest.mock('i18next-express-middleware', () => ({
   handle: jest.fn(() => jest.fn()),
@@ -59,8 +60,8 @@ describe('next-18next middleware', () => {
         }))
   })
 
-  it('does not call any next-i18next middleware if localeSubpaths === false', () => {
-    nexti18next.config.localeSubpaths = false
+  it(`does not call any next-i18next middleware if localeSubpaths is "${localeSubpathOptions.NONE}"`, () => {
+    nexti18next.config.localeSubpaths = localeSubpathOptions.NONE
 
     callAllMiddleware()
 
@@ -68,9 +69,9 @@ describe('next-18next middleware', () => {
     expect(lngPathDetector).not.toBeCalled()
   })
 
-  describe('localeSubpaths === true', () => {
+  describe(`localeSubpaths = "${localeSubpathOptions.FOREIGN}"`, () => {
     beforeEach(() => {
-      nexti18next.config.localeSubpaths = true
+      nexti18next.config.localeSubpaths = localeSubpathOptions.FOREIGN
     })
 
     it('does not call middleware, if route to ignore', () => {

--- a/__tests__/router/wrap-router.test.js
+++ b/__tests__/router/wrap-router.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import NextRouter from 'next/router'
 import wrapRouter from '../../src/router/wrap-router'
+import { localeSubpathOptions } from '../../src/config/default-config'
 
 jest.mock('next/router', () => ({
   asPath: '/some-path',
@@ -32,7 +33,7 @@ const nextI18NextConfig = {
   },
   config: {
     defaultLanguage: 'en',
-    localeSubpaths: false,
+    localeSubpaths: localeSubpathOptions.NONE,
     allLanguages: ['en', 'de'],
   },
 }
@@ -112,7 +113,7 @@ describe('wrapRouter', () => {
       NextRouter.push.mockClear()
       NextRouter.replace.mockClear()
       NextRouter.prefetch.mockClear()
-      nextI18NextConfig.config.localeSubpaths = true
+      nextI18NextConfig.config.localeSubpaths = localeSubpathOptions.FOREIGN
       router = wrapRouter(nextI18NextConfig)
     })
 

--- a/__tests__/utils/lng-path-corrector.test.js
+++ b/__tests__/utils/lng-path-corrector.test.js
@@ -3,6 +3,7 @@
 import { format } from 'url'
 
 import lngPathCorrector from '../../src/utils/lng-path-corrector'
+import { localeSubpathOptions } from '../../src/config/default-config'
 
 describe('lngPathCorrector utility function', () => {
   let config
@@ -177,10 +178,10 @@ describe('lngPathCorrector utility function', () => {
       expect(format(result.href)).toEqual('/somewhere/else?option1=value1#hash1')
     })
 
-    it('does not remove default language from as when defaultLocaleSubpath is true', () => {
+    it(`does not remove default language from as when localeSubpath is "${localeSubpathOptions.ALL}"`, () => {
       currentRoute.as = '/en/foo'
       currentRoute.href = '/somewhere/else?option1=value1#hash1'
-      config.defaultLocaleSubpath = true
+      config.localeSubpaths = localeSubpathOptions.ALL
 
       const result = lngPathCorrector(config, currentRoute, 'en')
       expect(result.as).toEqual('/en/foo')

--- a/__tests__/utils/lng-path-detector.test.js
+++ b/__tests__/utils/lng-path-detector.test.js
@@ -3,6 +3,7 @@
 import testI18NextConfig from '../test-i18next-config'
 
 import lngPathDetector from '../../src/utils/lng-path-detector'
+import { localeSubpathOptions } from '../../src/config/default-config'
 
 describe('lngPathDetector utility function', () => {
   let req
@@ -60,9 +61,9 @@ describe('lngPathDetector utility function', () => {
     expect(res.redirect).toBeCalledWith(302, '/foo')
   })
 
-  it('does not redirect if language is languages[0] and defaultLocaleSubpath is true ', () => {
+  it(`does not redirect if language is languages[0] and localeSubpaths is "${localeSubpathOptions.ALL}"`, () => {
     req.i18n.languages = ['en', 'de']
-    req.i18n.options.defaultLocaleSubpath = true
+    req.i18n.options.localeSubpaths = localeSubpathOptions.ALL
     req.url = '/en/foo'
 
     lngPathDetector(req, res, true)

--- a/examples/simple/__tests__/e2e/basic.test.js
+++ b/examples/simple/__tests__/e2e/basic.test.js
@@ -7,6 +7,10 @@ const testLanguageSecondary = 'de'
 
 describe('example project', () => {
   beforeAll(async () => {
+    await page.close()
+    const context = await browser.createIncognitoBrowserContext()
+    page = await context.newPage()
+
     await page.setExtraHTTPHeaders({
       'Accept-Language': testLanguage,
     })

--- a/examples/simple/__tests__/e2e/locale-subpaths-all.test.js
+++ b/examples/simple/__tests__/e2e/locale-subpaths-all.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+/* eslint-disable no-undef */
+const jestPuppeteerConfig = require('../../../../jest-puppeteer.config')
+
+const testLanguage = 'en'
+const testLanguageSecondary = 'de'
+
+describe('example project with localeSubpaths set to all', () => {
+  beforeAll(async () => {
+    await page.close()
+    const context = await browser.createIncognitoBrowserContext()
+    page = await context.newPage()
+
+    await page.setExtraHTTPHeaders({
+      'Accept-Language': testLanguage,
+    })
+    await page.goto(`http://localhost:${jestPuppeteerConfig.e2eTests.LOCALE_SUBPATHS_ALL.port}/`)
+    await page.waitForSelector('html')
+    await expect(page.url()).toBe(`http://localhost:${jestPuppeteerConfig.e2eTests.LOCALE_SUBPATHS_ALL.port}/en/`)
+  })
+
+  describe(`changing to ${testLanguageSecondary} locale`, () => {
+    beforeAll(async () => {
+      await expect(page).toClick('button', { text: 'Change locale' })
+      await page.waitForNavigation()
+      await expect(page.url()).toBe(`http://localhost:${jestPuppeteerConfig.e2eTests.LOCALE_SUBPATHS_ALL.port}/${testLanguageSecondary}/`)
+    })
+
+    it(`should display h1 in ${testLanguageSecondary} locale`, async () => {
+      await expect(page).toMatch('Ein einfaches Beispiel')
+    })
+  })
+})

--- a/examples/simple/__tests__/e2e/locale-subpaths-foreign.test.js
+++ b/examples/simple/__tests__/e2e/locale-subpaths-foreign.test.js
@@ -5,19 +5,24 @@ const jestPuppeteerConfig = require('../../../../jest-puppeteer.config')
 const testLanguage = 'en'
 const testLanguageSecondary = 'de'
 
-describe('example project with localeSubpaths enabled', () => {
+describe('example project with localeSubpaths set to foreign', () => {
   beforeAll(async () => {
+    await page.close()
+    const context = await browser.createIncognitoBrowserContext()
+    page = await context.newPage()
     await page.setExtraHTTPHeaders({
       'Accept-Language': testLanguage,
     })
-    await page.goto(`http://localhost:${jestPuppeteerConfig.e2eTests.LOCALE_SUBPATHS.port}/`)
+    await page.goto(`http://localhost:${jestPuppeteerConfig.e2eTests.LOCALE_SUBPATHS_FOREIGN.port}/`)
+    await page.waitForSelector('html')
+    await expect(page.url()).toBe(`http://localhost:${jestPuppeteerConfig.e2eTests.LOCALE_SUBPATHS_FOREIGN.port}/`)
   })
 
   describe(`changing to ${testLanguageSecondary} locale`, () => {
     beforeAll(async () => {
       await expect(page).toClick('button', { text: 'Change locale' })
       await page.waitForNavigation()
-      await expect(page.url()).toBe(`http://localhost:${jestPuppeteerConfig.e2eTests.LOCALE_SUBPATHS.port}/${testLanguageSecondary}/`)
+      await expect(page.url()).toBe(`http://localhost:${jestPuppeteerConfig.e2eTests.LOCALE_SUBPATHS_FOREIGN.port}/${testLanguageSecondary}/`)
     })
 
     it(`should display h1 in ${testLanguageSecondary} locale`, async () => {

--- a/examples/simple/next.config.js
+++ b/examples/simple/next.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   publicRuntimeConfig: {
-    localeSubpaths: process.env.LOCALE_SUBPATHS === 'true',
+    localeSubpaths: typeof process.env.LOCALE_SUBPATHS === 'string'
+      ? process.env.LOCALE_SUBPATHS
+      : 'none',
   },
 }

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -6,8 +6,11 @@ const e2eTests = {
   BASIC: {
     port: 4001,
   },
-  LOCALE_SUBPATHS: {
+  LOCALE_SUBPATHS_FOREIGN: {
     port: 4002,
+  },
+  LOCALE_SUBPATHS_ALL: {
+    port: 4003,
   },
 }
 
@@ -20,9 +23,14 @@ module.exports = {
       command: `cd examples/simple && PORT=${e2eTests.BASIC.port} NODE_ENV=production node index.js`,
     },
     {
-      ...e2eTests.LOCALE_SUBPATHS,
+      ...e2eTests.LOCALE_SUBPATHS_FOREIGN,
       ...defaults,
-      command: `cd examples/simple && LOCALE_SUBPATHS=true PORT=${e2eTests.LOCALE_SUBPATHS.port} NODE_ENV=production node index.js`,
+      command: `cd examples/simple && LOCALE_SUBPATHS=foreign PORT=${e2eTests.LOCALE_SUBPATHS_FOREIGN.port} NODE_ENV=production node index.js`,
+    },
+    {
+      ...e2eTests.LOCALE_SUBPATHS_ALL,
+      ...defaults,
+      command: `cd examples/simple && LOCALE_SUBPATHS=all PORT=${e2eTests.LOCALE_SUBPATHS_ALL.port} NODE_ENV=production node index.js`,
     },
   ],
 }

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -77,7 +77,7 @@ Link.propTypes = {
   nextI18NextConfig: PropTypes.shape({
     config: PropTypes.shape({
       defaultLanguage: PropTypes.string.isRequired,
-      localeSubpaths: PropTypes.bool.isRequired,
+      localeSubpaths: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
 }

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -1,10 +1,15 @@
+export const localeSubpathOptions = {
+  ALL: 'all',
+  FOREIGN: 'foreign',
+  NONE: 'none',
+}
+
 const DEFAULT_LANGUAGE = 'en'
 const OTHER_LANGUAGES = []
 const DEFAULT_NAMESPACE = 'common'
 const LOCALE_PATH = 'static/locales'
 const LOCALE_STRUCTURE = '{{lng}}/{{ns}}'
-const LOCALE_SUBPATHS = false
-const DEFAULT_LOCALE_SUBPATH = false
+const LOCALE_SUBPATHS = localeSubpathOptions.NONE
 
 export default {
   defaultLanguage: DEFAULT_LANGUAGE,
@@ -13,7 +18,6 @@ export default {
   localePath: LOCALE_PATH,
   localeStructure: LOCALE_STRUCTURE,
   localeSubpaths: LOCALE_SUBPATHS,
-  defaultLocaleSubpath: DEFAULT_LOCALE_SUBPATH,
   ns: [DEFAULT_NAMESPACE],
   use: [],
   defaultNS: DEFAULT_NAMESPACE,

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -5,6 +5,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics'
 import { I18nextProvider } from 'react-i18next'
 
 import { lngFromReq, lngPathCorrector } from '../utils'
+import { localeSubpathOptions } from '../config/default-config'
 import { NextStaticProvider } from '../components'
 
 export default function (WrappedComponent) {
@@ -16,7 +17,7 @@ export default function (WrappedComponent) {
     constructor(props) {
       super(props)
 
-      if (process.browser && config.localeSubpaths) {
+      if (process.browser && config.localeSubpaths !== localeSubpathOptions.NONE) {
         i18n.on('languageChanged', (lng) => {
           const { router } = props
           const { pathname, asPath, query } = router

--- a/src/middlewares/next-i18next-middleware.js
+++ b/src/middlewares/next-i18next-middleware.js
@@ -3,6 +3,7 @@ import { parse } from 'url'
 import pathMatch from 'path-match'
 
 import { forceTrailingSlash, lngPathDetector } from '../utils'
+import { localeSubpathOptions } from '../config/default-config'
 
 const route = pathMatch()
 
@@ -32,7 +33,7 @@ export default function (nexti18next) {
 
   middleware.push(i18nextMiddleware.handle(i18n, { ignoreRoutes }))
 
-  if (localeSubpaths) {
+  if (localeSubpaths !== localeSubpathOptions.NONE) {
     middleware.push(
       (req, res, next) => {
         if (isI18nRoute(req.url)) {

--- a/src/utils/lng-path-corrector.js
+++ b/src/utils/lng-path-corrector.js
@@ -1,4 +1,5 @@
 import { format as formatUrl, parse as parseUrl } from 'url'
+import { localeSubpathOptions } from '../config/default-config'
 
 const parseAs = (originalAs, href) => {
   const asType = typeof originalAs
@@ -32,7 +33,7 @@ const parseHref = (originalHref) => {
 }
 
 export default (config, currentRoute, currentLanguage) => {
-  const { defaultLanguage, allLanguages, defaultLocaleSubpath } = config
+  const { defaultLanguage, allLanguages, localeSubpaths } = config
   const { as: originalAs, href: originalHref } = currentRoute
 
   if (!allLanguages.includes(currentLanguage)) {
@@ -53,7 +54,7 @@ export default (config, currentRoute, currentLanguage) => {
     }
   }
 
-  if (currentLanguage !== defaultLanguage || defaultLocaleSubpath) {
+  if (currentLanguage !== defaultLanguage || localeSubpaths === localeSubpathOptions.ALL) {
     as = `/${currentLanguage}${as}`
     href.query.lng = currentLanguage
   }

--- a/src/utils/lng-path-detector.js
+++ b/src/utils/lng-path-detector.js
@@ -1,10 +1,11 @@
 import lngFromReq from './lng-from-req'
 import redirectWithoutCache from './redirect-without-cache'
+import { localeSubpathOptions } from '../config/default-config'
 
 export default (req, res) => {
   if (req.i18n) {
     const language = lngFromReq(req)
-    const { allLanguages, defaultLanguage, defaultLocaleSubpath } = req.i18n.options
+    const { allLanguages, defaultLanguage, localeSubpaths } = req.i18n.options
     let languageChanged = false
     /*
       If a user has hit a subpath which does not
@@ -23,7 +24,11 @@ export default (req, res) => {
       preference to the language and redirect
       their path.
     */
-    if (!languageChanged && language !== defaultLanguage && !req.url.startsWith(`/${language}/`)) {
+    const languageNeedsSubpath = (localeSubpaths === localeSubpathOptions.FOREIGN
+      && language !== defaultLanguage)
+      || localeSubpaths === localeSubpathOptions.ALL
+
+    if (!languageChanged && languageNeedsSubpath && !req.url.startsWith(`/${language}/`)) {
       allLanguages.forEach((lng) => {
         if (req.url.startsWith(`/${lng}/`)) {
           req.url = req.url.replace(`/${lng}/`, '/')
@@ -35,7 +40,9 @@ export default (req, res) => {
       If a user has a default language prefix
       in their URL, strip it.
     */
-    if (language === defaultLanguage && req.url.startsWith(`/${defaultLanguage}/`) && !defaultLocaleSubpath) {
+    if (language === defaultLanguage
+        && req.url.startsWith(`/${defaultLanguage}/`)
+        && localeSubpaths !== localeSubpathOptions.ALL) {
       redirectWithoutCache(res, req.url.replace(`/${defaultLanguage}/`, '/'))
     }
   }

--- a/src/utils/locale-subpath-required.js
+++ b/src/utils/locale-subpath-required.js
@@ -1,5 +1,27 @@
-export default (nextI18NextConfig, lng) => {
-  const { defaultLanguage, localeSubpaths, defaultLocaleSubpath } = nextI18NextConfig.config
+import { localeSubpathOptions } from '../config/default-config'
 
-  return localeSubpaths && lng && (lng !== defaultLanguage || defaultLocaleSubpath)
+export default (nextI18NextConfig, lng) => {
+  const {
+    defaultLanguage,
+    localeSubpaths,
+  } = nextI18NextConfig.config
+
+  if (lng) {
+
+    if (localeSubpaths === localeSubpathOptions.NONE) {
+      return false
+    }
+
+    if (localeSubpaths === localeSubpathOptions.FOREIGN && lng !== defaultLanguage) {
+      return true
+    }
+
+    if (localeSubpaths === localeSubpathOptions.ALL) {
+      return true
+    }
+
+  }
+
+  return false
+
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -13,7 +13,7 @@ export interface INextI18NextConfig {
   localePath: string;
   localeStructure: string;
   otherLanguages: string[];
-  localeSubpaths: boolean;
+  localeSubpaths: string;
   use: any[];
   customDetectors: any[];
 }


### PR DESCRIPTION
This changes the `localeSubpaths` config option from a boolean to an enum of strings: `none`, `foreign`, and `all`. We may add more options in the future (eg regional locales).

I've also added a new e2e test, and we're now covering each of these three `localeSubpaths` options with an e2e test.

Fixes #211.