### PR TITLE
feat(types): add return type for withNamespaces function

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { TransProps } from 'react-i18next';
+import {
+  TransProps,
+  Namespace,
+  NamespaceExtractor,
+  WithNamespacesOptions,
+  WithNamespaces,
+  Subtract
+} from 'react-i18next';
 import { LinkProps } from 'next-server/link';
 import { SingletonRouter } from 'next-server/router';
 import i18next from 'i18next';
@@ -26,7 +33,12 @@ declare class NextI18Next {
 
   constructor(config: Partial<INextI18NextConfig>);
 
-  withNamespaces(namespace: string | string[]): any;
+  withNamespaces(
+    namespace: Namespace | NamespaceExtractor,
+    options?: WithNamespacesOptions
+  ): <P extends WithNamespaces>(
+    component: React.ComponentType<P>
+  ) => React.ComponentType<Subtract<P, WithNamespaces>>;
 
   appWithTranslation<P extends object>(Component: React.ComponentType<P>): any;
 }


### PR DESCRIPTION
Type checking does not work bacause of return type `any` of a `withNamespaces` function.

![image](https://user-images.githubusercontent.com/5487217/54424220-b731fa00-4712-11e9-9c75-ecc33f48ac08.png)

Type casting helped, but it's not the correct behaviour:

![image](https://user-images.githubusercontent.com/5487217/54424290-dd579a00-4712-11e9-9498-3a9f620cc9a8.png)
