### PR TITLE
fix(types): return Component type in appWithTranslation

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -40,7 +40,7 @@ declare class NextI18Next {
     component: React.ComponentType<P>
   ) => React.ComponentType<Subtract<P, WithNamespaces>>;
 
-  appWithTranslation<P extends object>(Component: React.ComponentType<P>): any;
+  appWithTranslation<P extends object>(Component: React.ComponentType<P> | React.ElementType<P>): any;
 }
 
 export default NextI18Next;


### PR DESCRIPTION
The same issue as here: https://github.com/isaachinman/next-i18next/issues/220#issuecomment-471028160

But the merged code was removed later in https://github.com/isaachinman/next-i18next/pull/225/files