### PR TITLE
fix(types): remove extends of WithNamespaces

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -25,6 +25,10 @@ export interface INextI18NextConfig {
   customDetectors: any[];
 }
 
+export interface I18nProps {
+  t(key: string, option?: object): string;
+}
+
 declare class NextI18Next {
   Trans: React.ComponentClass<TransProps>;
   Link: React.ComponentClass<LinkProps>;
@@ -35,10 +39,10 @@ declare class NextI18Next {
 
   withNamespaces(
     namespace: Namespace | NamespaceExtractor,
-    options?: WithNamespacesOptions
-  ): <P extends WithNamespaces>(
-    component: React.ComponentType<P>
-  ) => React.ComponentType<Subtract<P, WithNamespaces>>;
+    options?: WithNamespacesOptions,
+  ): <T extends React.ComponentType<any>>(
+    component: T,
+  ) => T & (T extends React.ComponentType<infer P> ? React.ComponentType<Subtract<P, I18nProps>> : never);
 
   appWithTranslation<P extends object>(Component: React.ComponentType<P> | React.ElementType<P>): any;
 }


### PR DESCRIPTION
- Removed `extends WithNamespaces`, let the developer uses his own types for the component. 
- Do not enforce developer to define I18n `t` function (removal of extends - e.g. `React.SFC<{myProp: string}>`)
- If the developer wants to use the `t` function in his Component, he has to set props with I18nProps interface (`React.SFC<I18nProps>`) or extend his own interface with I18nProps (`interface CustomProps extends I18nProps { myProp: string }`)

Now the typing works correctly:

```
yarn run v1.13.0
$ rimraf ./build && next build && tsc
Creating an optimized production build ...

> Using external babel configuration
> Location: "/Users/prokop/Sites/_yoyo/xoxo/.babelrc"
Compiled successfully.

 ┌ /
 ├ /_app
 ├ /_document
 ├ /_error
 ├ /principles
 └ /signers

pages/index.tsx:21:10 - error TS2739: Type '{ totalCount: any; signers: any; }' is missing the following properties from type 'Pick<SignProps, "content" | "signers" | "totalCount" | "manifesto" | "currentUser">': content, manifesto

21         <Sign totalCount={props.totalCount} signers={props.signers} />
            ~~~~

pages/index.tsx:22:10 - error TS2739: Type '{ totalCount: any; signers: any; }' is missing the following properties from type 'Pick<AvatarsProps, "content" | "signers" | "totalCount" | "manifesto" | "currentUser">': content, manifesto

22         <Avatars totalCount={props.totalCount} signers={props.signers} />
            ~~~~~~~


Found 2 errors.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

@isaachinman Sorry for that mistake.

