### PR TITLE
fix(types): remove T from return types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -42,7 +42,7 @@ declare class NextI18Next {
     options?: WithNamespacesOptions,
   ): <T extends React.ComponentType<any>>(
     component: T,
-  ) => T & (T extends React.ComponentType<infer P> ? React.ComponentType<Subtract<P, I18nProps>> : never);
+  ) => T extends React.ComponentType<infer P> ? React.ComponentType<Subtract<P, I18nProps>> : never;
 
   appWithTranslation<P extends object>(Component: React.ComponentType<P> | React.ElementType<P>): any;
 }


### PR DESCRIPTION
Remove T from return types because it requires `t` function in props and it's not necessary.

before:
![image](https://user-images.githubusercontent.com/5487217/54596774-a0064b80-4a35-11e9-9045-15aee054a64a.png)

after:
![image](https://user-images.githubusercontent.com/5487217/54596953-f7a4b700-4a35-11e9-9b7a-d10252e06237.png)


pls check if it works for you @felixmosh 