### PR TITLE
add builtins inline, polyfills for ie11 and higher support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,8 +6,10 @@
           "@babel/env",
           {
             "modules": false,
+            "useBuiltIns": "usage",
             "targets": {
-              "node": "current"
+              "node": "current",
+              "ie": "11"
             }
           }
         ],
@@ -23,6 +25,13 @@
             "regenerator": true,
             "useESModules": false
           },
+          "preset-env": {
+            "useBuiltIns": "usage",
+            "targets": {
+              "node": "current",
+              "ie": "11"
+            }
+          }
         }]
       ],
       "plugins": [


### PR DESCRIPTION
This PR will fix #290 and include all required pollyfills in order to support browsers with restricted set of ES6/7 features. This is aligned to next.js [strategy](https://github.com/zeit/next.js#browser-support). Next.js is already delivered with `core.js` and builtIns are only imported once as documented [here](https://babeljs.io/docs/en/babel-preset-env#usebuiltins-usage-experimental)

> Adds specific imports for polyfills when they are used in each file. We take advantage of the fact that a bundler will load the same polyfill only once.