### PR TITLE
fix: Do not call next() after redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ After creating and exporting your `NextI18Next` instance, you need to take the f
 1. Create an `_app.js` file inside your `pages` directory, and wrap it with the `NextI18Next.appWithTranslation` higher order component (HOC). You can see this approach in the [examples/simple/pages/_app.js](./examples/simple/pages/_app.js). 
 2. Create a `server.js` file inside your root directory, initialise an [express](https://www.npmjs.com/package/express) server, and use the `nextI18NextMiddleware` middleware with your `nextI18Next` instance passed in. You can see this approach in the [examples/simple/server.js](./examples/simple/server.js). For more info, see [the NextJs section on custom servers](https://github.com/zeit/next.js#custom-server-and-routing).
 
+    When using the `localeSubpaths` option, our middleware may redirect without calling any subsequent middleware.  Therefore, if there are any critical middleware that must run before this redirect, ensure that you place it before the `nextI18NextMiddleware` middleware.
+
 That's it! Your app is ready to go. You can now use the `NextI18Next.withNamespaces` HOC to make your components or pages translatable, based on namespaces:
 
 ```jsx
@@ -134,6 +136,8 @@ myapp.com/fr/
 myapp.com/de/
 myapp.com/es/
 ```
+
+When using the localeSubpaths option, our middleware may redirect without calling any subsequent middleware.  Therefore, if there are any critical middleware that must run before this redirect, ensure that you place it before the `nextI18NextMiddleware` middleware.
 
 The main "gotcha" with locale subpaths is routing. We want to be able to route to "naked" routes, and not have to worry about the locale subpath part of the route:
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ After creating and exporting your `NextI18Next` instance, you need to take the f
 1. Create an `_app.js` file inside your `pages` directory, and wrap it with the `NextI18Next.appWithTranslation` higher order component (HOC). You can see this approach in the [examples/simple/pages/_app.js](./examples/simple/pages/_app.js). 
 2. Create a `server.js` file inside your root directory, initialise an [express](https://www.npmjs.com/package/express) server, and use the `nextI18NextMiddleware` middleware with your `nextI18Next` instance passed in. You can see this approach in the [examples/simple/server.js](./examples/simple/server.js). For more info, see [the NextJs section on custom servers](https://github.com/zeit/next.js#custom-server-and-routing).
 
-    When using the `localeSubpaths` option, our middleware may redirect without calling any subsequent middleware.  Therefore, if there are any critical middleware that must run before this redirect, ensure that you place it before the `nextI18NextMiddleware` middleware.
-
 That's it! Your app is ready to go. You can now use the `NextI18Next.withNamespaces` HOC to make your components or pages translatable, based on namespaces:
 
 ```jsx

--- a/__tests__/middlewares/next-i18next-middleware.test.js
+++ b/__tests__/middlewares/next-i18next-middleware.test.js
@@ -38,7 +38,6 @@ describe('next-18next middleware', () => {
     lngPathDetector.mockImplementation(() => ({
       originalUrl: '/page',
       correctedUrl: '/page',
-      redirectRequired: false,
     }))
   })
 
@@ -130,14 +129,14 @@ describe('next-18next middleware', () => {
       it('does not call next() if lngPathDetector redirects', () => {
         req.url = '/page/'
         lngPathDetector.mockImplementation(() => ({
-          redirectRequired: true,
-          correctedUrl: '/de/page',
+          originalUrl: '/page/',
+          correctedUrl: '/de/page/',
         }))
 
         callAllMiddleware()
 
         expect(lngPathDetector).toBeCalledWith(req)
-        expect(redirectWithoutCache).toBeCalledWith(res, '/de/page')
+        expect(redirectWithoutCache).toBeCalledWith(res, '/de/page/')
 
         expect(next).toBeCalledTimes(1)
       })
@@ -145,7 +144,8 @@ describe('next-18next middleware', () => {
       it('calls next() if lngPathDetector does not redirect', () => {
         req.url = '/page/'
         lngPathDetector.mockImplementation(() => ({
-          redirectRequired: false,
+          originalUrl: '/page/',
+          correctedUrl: '/page/',
         }))
 
         callAllMiddleware()

--- a/__tests__/utils/lng-path-detector.test.js
+++ b/__tests__/utils/lng-path-detector.test.js
@@ -7,62 +7,59 @@ import { localeSubpathOptions } from '../../src/config/default-config'
 
 describe('lngPathDetector utility function', () => {
   let req
-  let res
 
   beforeEach(() => {
     req = {
       i18n: testI18NextConfig,
       url: '/',
     }
-
-    res = {
-      redirect: jest.fn(),
-      header: jest.fn(),
-    }
   })
 
   it('skips everything if req.i18n is not defined', () => {
+    req.url = '/foo'
     delete req.i18n
 
-    const redirectPerformed = lngPathDetector(req, res)
+    const config = lngPathDetector(req)
 
-    expect(redirectPerformed).toBe(false)
-    expect(res.redirect).not.toBeCalled()
+    expect(config.redirectRequired).toBe(false)
+    expect(config.correctedUrl).toBe(config.originalUrl)
   })
 
   it('changes language if url starts with language and is not languages[0]', () => {
     req.url = '/de/foo'
 
-    const redirectPerformed = lngPathDetector(req, res)
+    const config = lngPathDetector(req)
 
     expect(req.i18n.changeLanguage).toBeCalledWith('de')
 
-    expect(redirectPerformed).toBe(false)
-    expect(res.redirect).not.toBeCalled()
+    expect(config.redirectRequired).toBe(false)
+    expect(config.correctedUrl).toBe(config.originalUrl)
   })
 
   it('performs language change if url starts with a locale subpath of a different locale', () => {
     req.i18n.languages = ['de', 'en']
     req.url = '/en/foo?test=123'
 
-    const redirectPerformed = lngPathDetector(req, res)
+    const config = lngPathDetector(req)
 
     expect(req.i18n.changeLanguage).toBeCalledWith('en')
 
-    expect(redirectPerformed).toBe(false)
-    expect(res.redirect).not.toBeCalledWith()
+    expect(config.redirectRequired).toBe(false)
+    expect(config.correctedUrl).toBe(config.originalUrl)
   })
 
   it('strips language off url and redirects if language is languages[0]', () => {
     req.i18n.languages = ['en', 'de']
     req.url = '/en/foo'
 
-    const redirectPerformed = lngPathDetector(req, res, true)
+    const config = lngPathDetector(req)
 
     expect(req.i18n.changeLanguage).not.toBeCalledWith()
 
-    expect(redirectPerformed).toBe(true)
-    expect(res.redirect).toBeCalledWith(302, '/foo')
+    expect(config.redirectRequired).toBe(true)
+    expect(config.correctedUrl).not.toBe(config.originalUrl)
+    expect(config.originalUrl).toBe('/en/foo')
+    expect(config.correctedUrl).toBe('/foo')
   })
 
   it(`does not redirect if language is languages[0] and localeSubpaths is "${localeSubpathOptions.ALL}"`, () => {
@@ -70,9 +67,9 @@ describe('lngPathDetector utility function', () => {
     req.i18n.options.localeSubpaths = localeSubpathOptions.ALL
     req.url = '/en/foo'
 
-    const redirectPerformed = lngPathDetector(req, res, true)
+    const config = lngPathDetector(req)
 
-    expect(redirectPerformed).toBe(false)
-    expect(res.redirect).not.toBeCalled()
+    expect(config.redirectRequired).toBe(false)
+    expect(config.correctedUrl).toBe(config.originalUrl)
   })
 })

--- a/__tests__/utils/lng-path-detector.test.js
+++ b/__tests__/utils/lng-path-detector.test.js
@@ -21,7 +21,6 @@ describe('lngPathDetector utility function', () => {
 
     const config = lngPathDetector(req)
 
-    expect(config.redirectRequired).toBe(false)
     expect(config.correctedUrl).toBe(config.originalUrl)
   })
 
@@ -32,7 +31,6 @@ describe('lngPathDetector utility function', () => {
 
     expect(req.i18n.changeLanguage).toBeCalledWith('de')
 
-    expect(config.redirectRequired).toBe(false)
     expect(config.correctedUrl).toBe(config.originalUrl)
   })
 
@@ -44,7 +42,6 @@ describe('lngPathDetector utility function', () => {
 
     expect(req.i18n.changeLanguage).toBeCalledWith('en')
 
-    expect(config.redirectRequired).toBe(false)
     expect(config.correctedUrl).toBe(config.originalUrl)
   })
 
@@ -56,7 +53,6 @@ describe('lngPathDetector utility function', () => {
 
     expect(req.i18n.changeLanguage).not.toBeCalledWith()
 
-    expect(config.redirectRequired).toBe(true)
     expect(config.correctedUrl).not.toBe(config.originalUrl)
     expect(config.originalUrl).toBe('/en/foo')
     expect(config.correctedUrl).toBe('/foo')
@@ -69,7 +65,6 @@ describe('lngPathDetector utility function', () => {
 
     const config = lngPathDetector(req)
 
-    expect(config.redirectRequired).toBe(false)
     expect(config.correctedUrl).toBe(config.originalUrl)
   })
 })

--- a/__tests__/utils/lng-path-detector.test.js
+++ b/__tests__/utils/lng-path-detector.test.js
@@ -24,18 +24,20 @@ describe('lngPathDetector utility function', () => {
   it('skips everything if req.i18n is not defined', () => {
     delete req.i18n
 
-    lngPathDetector(req, res)
+    const redirectPerformed = lngPathDetector(req, res)
 
+    expect(redirectPerformed).toBe(false)
     expect(res.redirect).not.toBeCalled()
   })
 
   it('changes language if url starts with language and is not languages[0]', () => {
     req.url = '/de/foo'
 
-    lngPathDetector(req, res)
+    const redirectPerformed = lngPathDetector(req, res)
 
     expect(req.i18n.changeLanguage).toBeCalledWith('de')
 
+    expect(redirectPerformed).toBe(false)
     expect(res.redirect).not.toBeCalled()
   })
 
@@ -43,10 +45,11 @@ describe('lngPathDetector utility function', () => {
     req.i18n.languages = ['de', 'en']
     req.url = '/en/foo?test=123'
 
-    lngPathDetector(req, res)
+    const redirectPerformed = lngPathDetector(req, res)
 
     expect(req.i18n.changeLanguage).toBeCalledWith('en')
 
+    expect(redirectPerformed).toBe(false)
     expect(res.redirect).not.toBeCalledWith()
   })
 
@@ -54,10 +57,11 @@ describe('lngPathDetector utility function', () => {
     req.i18n.languages = ['en', 'de']
     req.url = '/en/foo'
 
-    lngPathDetector(req, res, true)
+    const redirectPerformed = lngPathDetector(req, res, true)
 
     expect(req.i18n.changeLanguage).not.toBeCalledWith()
 
+    expect(redirectPerformed).toBe(true)
     expect(res.redirect).toBeCalledWith(302, '/foo')
   })
 
@@ -66,8 +70,9 @@ describe('lngPathDetector utility function', () => {
     req.i18n.options.localeSubpaths = localeSubpathOptions.ALL
     req.url = '/en/foo'
 
-    lngPathDetector(req, res, true)
+    const redirectPerformed = lngPathDetector(req, res, true)
 
+    expect(redirectPerformed).toBe(false)
     expect(res.redirect).not.toBeCalled()
   })
 })

--- a/examples/simple/server.js
+++ b/examples/simple/server.js
@@ -14,7 +14,13 @@ const handle = app.getRequestHandler();
 
   server.use(nextI18NextMiddleware(nextI18next))
 
-  server.get('*', (req, res) => handle(req, res))
+  server.get('*', (req, res) => {
+    // the next line is included to test regression of https://github.com/isaachinman/next-i18next/issues/304
+    // Do not include it in your code
+    res.setHeader('X-Check-No-Fail', 'should not fail')
+
+    return handle(req, res)
+  })
 
   await server.listen(port)
   console.log(`> Ready on http://localhost:${port}`) // eslint-disable-line no-console

--- a/examples/simple/server.js
+++ b/examples/simple/server.js
@@ -14,13 +14,7 @@ const handle = app.getRequestHandler();
 
   server.use(nextI18NextMiddleware(nextI18next))
 
-  server.get('*', (req, res) => {
-    // the next line is included to test regression of https://github.com/isaachinman/next-i18next/issues/304
-    // Do not include it in your code
-    res.setHeader('X-Check-No-Fail', 'should not fail')
-
-    return handle(req, res)
-  })
+  server.get('*', (req, res) => handle(req, res))
 
   await server.listen(port)
   console.log(`> Ready on http://localhost:${port}`) // eslint-disable-line no-console

--- a/src/middlewares/next-i18next-middleware.js
+++ b/src/middlewares/next-i18next-middleware.js
@@ -49,7 +49,7 @@ export default function (nexti18next) {
     middleware.push((req, res, next) => {
       if (isI18nRoute(req.url)) {
         const lngPathDetectorConfig = lngPathDetector(req)
-        if (lngPathDetectorConfig.redirectRequired) {
+        if (lngPathDetectorConfig.originalUrl !== lngPathDetectorConfig.correctedUrl) {
           redirectWithoutCache(res, lngPathDetectorConfig.correctedUrl)
 
           return

--- a/src/middlewares/next-i18next-middleware.js
+++ b/src/middlewares/next-i18next-middleware.js
@@ -2,7 +2,7 @@ import i18nextMiddleware from 'i18next-express-middleware'
 import { parse } from 'url'
 import pathMatch from 'path-match'
 
-import { forceTrailingSlash, lngPathDetector } from '../utils'
+import { forceTrailingSlash, lngPathDetector, redirectWithoutCache } from '../utils'
 import { localeSubpathOptions } from '../config/default-config'
 
 const route = pathMatch()
@@ -48,8 +48,10 @@ export default function (nexti18next) {
 
     middleware.push((req, res, next) => {
       if (isI18nRoute(req.url)) {
-        const redirectPerformed = lngPathDetector(req, res)
-        if (redirectPerformed) {
+        const lngPathDetectorConfig = lngPathDetector(req)
+        if (lngPathDetectorConfig.redirectRequired) {
+          redirectWithoutCache(res, lngPathDetectorConfig.correctedUrl)
+
           return
         }
       }

--- a/src/utils/lng-path-detector.js
+++ b/src/utils/lng-path-detector.js
@@ -1,9 +1,12 @@
 import lngFromReq from './lng-from-req'
-import redirectWithoutCache from './redirect-without-cache'
 import { localeSubpathOptions } from '../config/default-config'
 
-export default (req, res) => {
-  let redirectPerformed = false
+export default (req) => {
+  const config = {
+    originalUrl: req.url,
+    correctedUrl: req.url,
+    redirectRequired: false,
+  }
 
   if (req.i18n) {
     const language = lngFromReq(req)
@@ -33,11 +36,10 @@ export default (req, res) => {
     if (!languageChanged && languageNeedsSubpath && !req.url.startsWith(`/${language}/`)) {
       allLanguages.forEach((lng) => {
         if (req.url.startsWith(`/${lng}/`)) {
-          req.url = req.url.replace(`/${lng}/`, '/')
+          config.correctedUrl = req.url.replace(`/${lng}/`, '/')
+          config.redirectRequired = true
         }
       })
-      redirectWithoutCache(res, req.url.replace('/', `/${language}/`))
-      redirectPerformed = true
     }
     /*
       If a user has a default language prefix
@@ -46,10 +48,10 @@ export default (req, res) => {
     if (language === defaultLanguage
         && req.url.startsWith(`/${defaultLanguage}/`)
         && localeSubpaths !== localeSubpathOptions.ALL) {
-      redirectWithoutCache(res, req.url.replace(`/${defaultLanguage}/`, '/'))
-      redirectPerformed = true
+      config.correctedUrl = req.url.replace(`/${defaultLanguage}/`, '/')
+      config.redirectRequired = true
     }
   }
 
-  return redirectPerformed
+  return config
 }

--- a/src/utils/lng-path-detector.js
+++ b/src/utils/lng-path-detector.js
@@ -5,7 +5,6 @@ export default (req) => {
   const config = {
     originalUrl: req.url,
     correctedUrl: req.url,
-    redirectRequired: false,
   }
 
   if (req.i18n) {
@@ -37,7 +36,6 @@ export default (req) => {
       allLanguages.forEach((lng) => {
         if (req.url.startsWith(`/${lng}/`)) {
           config.correctedUrl = req.url.replace(`/${lng}/`, '/')
-          config.redirectRequired = true
         }
       })
     }
@@ -49,7 +47,6 @@ export default (req) => {
         && req.url.startsWith(`/${defaultLanguage}/`)
         && localeSubpaths !== localeSubpathOptions.ALL) {
       config.correctedUrl = req.url.replace(`/${defaultLanguage}/`, '/')
-      config.redirectRequired = true
     }
   }
 

--- a/src/utils/lng-path-detector.js
+++ b/src/utils/lng-path-detector.js
@@ -3,6 +3,8 @@ import redirectWithoutCache from './redirect-without-cache'
 import { localeSubpathOptions } from '../config/default-config'
 
 export default (req, res) => {
+  let redirectPerformed = false
+
   if (req.i18n) {
     const language = lngFromReq(req)
     const { allLanguages, defaultLanguage, localeSubpaths } = req.i18n.options
@@ -35,6 +37,7 @@ export default (req, res) => {
         }
       })
       redirectWithoutCache(res, req.url.replace('/', `/${language}/`))
+      redirectPerformed = true
     }
     /*
       If a user has a default language prefix
@@ -44,6 +47,9 @@ export default (req, res) => {
         && req.url.startsWith(`/${defaultLanguage}/`)
         && localeSubpaths !== localeSubpathOptions.ALL) {
       redirectWithoutCache(res, req.url.replace(`/${defaultLanguage}/`, '/'))
+      redirectPerformed = true
     }
   }
+
+  return redirectPerformed
 }


### PR DESCRIPTION
If we perform a redirect in lngPathDetector (using localeSubpaths option), we do not want any subsequent processing of routes or middleware.  Thus, next() should not be called in our middleware if we redirect.  This change ensures that we do not process any further middleware or routes if we redirect in lngPathDetector.

Appropriate changes in unit and e2e tests have been made to ensure no regression occurs.

Additionally, documentation changes have been made to make it explicit that we may perform redirects within our middleware and, thus, the order in which you run our middleware is important.

Resolves #304.