### PR TITLE
fix: Load main language when initial language is locale specific

### DIFF
--- a/__tests__/utils/lngs-to-load.test.js
+++ b/__tests__/utils/lngs-to-load.test.js
@@ -47,4 +47,8 @@ describe('lngsToLoad utility function', () => {
     expect(lngsToLoad(undefined, { it: ['dk', 'en'] })).toMatchObject([])
   })
 
+  it('returns main language when initialLng is locale specific', () => {
+    const analysis = lngsToLoad('fr-FR', 'en', ['fr', 'nl', 'de', 'fr-BE', 'en-US'])
+    expect(analysis).toMatchObject(['fr-FR', 'en', 'fr'])
+  })
 })

--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -85,7 +85,7 @@ export default function (WrappedComponent) {
 
         // Detect the languages to load based upon the fallbackLng configuration
         const { fallbackLng } = config
-        const languagesToLoad = lngsToLoad(initialLanguage, fallbackLng)
+        const languagesToLoad = lngsToLoad(initialLanguage, fallbackLng, config.otherLanguages)
 
         // Initialise the store with the languagesToLoad and
         // necessary namespaces needed to render this specific tree

--- a/src/utils/lngs-to-load.js
+++ b/src/utils/lngs-to-load.js
@@ -1,4 +1,4 @@
-export default (initialLng, fallbackLng) => {
+export default (initialLng, fallbackLng, otherLanguages) => {
   const languages = []
 
   if (initialLng) {
@@ -23,6 +23,15 @@ export default (initialLng, fallbackLng) => {
     if (fallbackLng.default) {
       languages.push(fallbackLng.default)
     }
+  }
+
+  if (initialLng && initialLng.includes('-') && Array.isArray(otherLanguages)) {
+    const [languageFromLocale] = initialLng.split('-')
+    otherLanguages.forEach((otherLanguage) => {
+      if (otherLanguage === languageFromLocale) {
+        languages.push(otherLanguage)
+      }
+    })
   }
 
   return languages


### PR DESCRIPTION
In order to support [locals resolving](https://www.i18next.com/principles/fallback#locals-resolving) feature from i18next we need to load the main language of the locale-specific initial language.

Here is the use case:

The website supports the `fr` language however there is a legal related copy that only apply to France.

By creating a folder `/locales/fr-FR` we can add these locale-specific copies in there and make i18next fall back to the general `/locales/fr` language for the keys that it doesn't find on the specific folder.

ps: I implemented this in a way that doesn't impact the current usage. So if you only use global languages ( `fr, en, de, etc..`) nothing changes.