### PR TITLE
Adds useSuspense:false to react-i18next default config

### DIFF
--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -41,6 +41,7 @@ const config = {
   },
   react: {
     wait: true,
+    useSuspense: false,
   },
   strictMode: true,
   errorStackTraceLimit: 0,


### PR DESCRIPTION
As stated in the migration guide from (https://react.i18next.com/latest/migrating-v9-to-v10) this commit sets useSuspense to false in react-i18next default config.
