### PR TITLE
Types for react-i18next v10

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -3,7 +3,6 @@ import {
   useTranslation,
   TransProps,
   Namespace,
-  WithTranslation,
   withTranslation
 } from 'react-i18next';
 import { LinkProps } from 'next-server/link';

--- a/types.d.ts
+++ b/types.d.ts
@@ -3,10 +3,8 @@ import {
   useTranslation,
   TransProps,
   Namespace,
-  NamespaceExtractor,
-  WithTranslationOptions,
   WithTranslation,
-  Subtract
+  withTranslation
 } from 'react-i18next';
 import { LinkProps } from 'next-server/link';
 import { SingletonRouter } from 'next-server/router';
@@ -43,12 +41,7 @@ declare class NextI18Next {
 
   constructor(config: InitConfig);
 
-  withTranslation(
-    namespace: Namespace | NamespaceExtractor,
-    options?: WithTranslationOptions,
-  ): <P>(
-    component: React.ComponentType<P>,
-  ) => React.ComponentType<Subtract<P, WithTranslation>>;
+  withTranslation: typeof withTranslation;
 
   appWithTranslation<P extends object>(Component: React.ComponentType<P> | React.ElementType<P>): any;
 }


### PR DESCRIPTION
Fixes #345.

Removes imports which are non-existent since version 10 of react-i18next and uses the type for withTranslation directly from react-i18next.