### PR TITLE
feat: re-export type WithTranslation from react-i18next for single point of typing

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -3,7 +3,8 @@ import {
   useTranslation,
   TransProps,
   Namespace,
-  withTranslation
+  withTranslation,
+  WithTranslation
 } from 'react-i18next';
 import { LinkProps } from 'next-server/link';
 import { SingletonRouter } from 'next-server/router';
@@ -44,5 +45,7 @@ declare class NextI18Next {
 
   appWithTranslation<P extends object>(Component: React.ComponentType<P> | React.ElementType<P>): any;
 }
+
+export type WithTranslation = WithTranslation;
 
 export default NextI18Next;


### PR DESCRIPTION
If you use `next-i18next` with Typescript, typing `WithTranslation` is necessary for Props typing. The typing mainly includes the `t` function which is heavily used if you want to translate.

Re-exporting the typing from `react-i18next` would be cool because direct importing from this package isn't needed anymore. This causes higher updatability.