### PR TITLE
fix: namespacesRequired undefined based on example

### DIFF
--- a/examples/simple/pages/_app.js
+++ b/examples/simple/pages/_app.js
@@ -1,8 +1,18 @@
-import React from 'react'
-import App, { Container } from 'next/app'
-import { appWithTranslation } from '../i18n'
+import App, { Container } from 'next/app';
+import React from 'react';
+import { appWithTranslation } from '../i18n';
 
 class MyApp extends App {
+  static async getInitialProps({ Component, ctx }) {
+    let pageProps = {};
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx);
+    }
+
+    return { pageProps };
+  }
+  
   render() {
     const { Component, pageProps } = this.props
     return (

--- a/examples/simple/pages/_app.js
+++ b/examples/simple/pages/_app.js
@@ -1,18 +1,18 @@
-import App, { Container } from 'next/app';
-import React from 'react';
-import { appWithTranslation } from '../i18n';
+import App, { Container } from 'next/app'
+import React from 'react'
+import { appWithTranslation } from '../i18n'
 
 class MyApp extends App {
   static async getInitialProps({ Component, ctx }) {
-    let pageProps = {};
+    let pageProps = {}
 
     if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx);
+      pageProps = await Component.getInitialProps(ctx)
     }
 
-    return { pageProps };
+    return { pageProps }
   }
-  
+
   render() {
     const { Component, pageProps } = this.props
     return (


### PR DESCRIPTION
Adding `getInitialProps` call to fix namespacesRequired issue that occurs otherwise. Should be helpful to others as I made the same mistake.