### PR TITLE
don't pass initialI18nStore to withSSR on the server-side.

### DIFF
--- a/src/hocs/app-with-translation.js
+++ b/src/hocs/app-with-translation.js
@@ -133,9 +133,9 @@ export default function (WrappedComponent) {
         >
           <NextStaticProvider>
             <WrappedComponentWithSSR
-              initialLanguage={initialLanguage}
-              initialI18nStore={initialI18nStore}
               {...this.props}
+              initialLanguage={initialLanguage}
+              initialI18nStore={process.browser ? initialI18nStore : null}
             />
           </NextStaticProvider>
         </I18nextProvider>


### PR DESCRIPTION
* passing initial store on the server causes useSSR (used by
  withSSR) to overwrite the server's global i18next ResourceStore
* frontends will still pass the initial store so rehydration works

resolves https://github.com/isaachinman/next-i18next/issues/369

I don't know if this is the ideal fix, but this has resolved my issues in production. Another potential solution is to have [`useSSR`](https://github.com/i18next/react-i18next/blob/master/src/useSSR.js#L11) merge `initialI18nStore` into `ResourceStore` instead of replacing it.