### PR TITLE
feat: Re-export types I18n and TFunction from i18next

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -46,6 +46,8 @@ declare class NextI18Next {
   appWithTranslation<P extends object>(Component: React.ComponentType<P> | React.ElementType<P>): any;
 }
 
+export type TFunction = i18next.TFunction;
+export type I18n = i18next.i18n;
 export type WithTranslation = WithTranslation;
 
 export default NextI18Next;


### PR DESCRIPTION
Following up on the change in https://github.com/isaachinman/next-i18next/pull/361 ...

We also consume the types for `I18n` and `TFunction`. We currently have to import the `i18next` package, just to get a hold of these types. The version differences between `next-i18next`'s dependencies and ours regularly cause a type mess. This has also been requested in https://github.com/isaachinman/next-i18next/issues/375

Now that we made the first step towards re-exporting dependencies' types in the PR mentioned above, can we consider exposing these too? The reasoning is the same...

> Re-exporting the typing from `react-i18next` would be cool because direct importing from this package isn't needed anymore. This causes higher updatability.

Fixes #375 