### PR TITLE
Fix: appWithTranslation / withTranslation typings

### DIFF
--- a/__tests__/types.test.ts
+++ b/__tests__/types.test.ts
@@ -3,6 +3,6 @@ import {
   I18n,
   InitConfig,
   TFunction,
-  withTranslation,
   WithTranslation,
+  AppWithTranslation,
 } from '../types.d'

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { consoleMessage } from './utils'
 import { Link } from './components';
 import { wrapRouter } from './router';
 
-import { AppWithTranslation, Config, InitConfig, Trans as TransType, Link as LinkType, I18n, UseTranslation, withTranslation as WithTranslation, Router } from '../types'
+import { AppWithTranslation, Config, InitConfig, Trans as TransType, Link as LinkType, I18n, UseTranslation, WithTranslation, Router } from '../types'
 
 export { withTranslation } from 'react-i18next'
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -4,8 +4,7 @@ import * as React from 'react'
 import {
   useTranslation,
   TransProps,
-  withTranslation,
-  WithTranslation
+  withTranslation
 } from 'react-i18next'
 import { LinkProps } from 'next/link'
 import { SingletonRouter } from 'next/router'
@@ -39,8 +38,7 @@ export type UseTranslation = typeof useTranslation
 export type AppWithTranslation = <P extends object>(Component: React.ComponentType<P> | React.ElementType<P>) => any
 export type TFunction = i18next.TFunction
 export type I18n = i18next.i18n
-export type WithTranslation = WithTranslation
-export type withTranslation = typeof withTranslation
+export type WithTranslation = typeof withTranslation
 
 declare class NextI18Next {
   constructor(config: InitConfig);
@@ -51,6 +49,7 @@ declare class NextI18Next {
   config: Config
   useTranslation: UseTranslation
   withTranslation: WithTranslation
+  appWithTranslation: AppWithTranslation
 }
 
 export default NextI18Next


### PR DESCRIPTION
I've got several errors

1. error TS2339: Property `appWithTranslation` does not exist on type `NextI18Next`
2. Cannot invoke an expression whose type lacks a call signature. Type `WithTranslation` has no compatible call signatures. e.g. `withTranslation(i18nextNamespaces),`

`appWithTranslation` should be exported from type `NextI18Next` as it's exported in implementation.
`WithTranslation` type might be as function and as object, it depends on what we are looking for.