### PR TITLE
fix: update of i18next and react-i18next version to fix typescript 

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,14 +99,14 @@
     "core-js": "^2",
     "detect-node": "^2.0.4",
     "hoist-non-react-statics": "^3.2.0",
-    "i18next": "^17.0.4",
+    "i18next": "^17.0.9",
     "i18next-browser-languagedetector": "^3.0.0",
     "i18next-express-middleware": "^1.5.0",
     "i18next-node-fs-backend": "^2.1.0",
     "i18next-xhr-backend": "^3.0.0",
     "path-match": "^1.2.4",
     "prop-types": "^15.6.2",
-    "react-i18next": "^10.11.3",
+    "react-i18next": "^10.11.5",
     "url": "^0.11.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4502,10 +4502,10 @@ i18next-xhr-backend@^3.0.0:
   dependencies:
     "@babel/runtime" "^7.4.5"
 
-i18next@^17.0.4:
-  version "17.0.4"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-17.0.4.tgz#c690b9de0c950ff8abe626562d03c4144dd75030"
-  integrity sha512-+lwmv3FT8Sv/HwVPjkR6rtEFhgOqt9L/CTehzyxvL/NdkeUYbFZJfE57MsBToB6LFWg3d0sZJIVgYqCpWzUyLQ==
+i18next@^17.0.9:
+  version "17.0.9"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-17.0.9.tgz#5f835e91a34fa5e7da1e5ae4c4586c81d7c4b17f"
+  integrity sha512-fCYpm3TDzcfPIPN3hmgvC/QJx17QHI+Ul88qbixwIrifN9nBmk2c2oVxVYSDxnV5FgBXZJJ0O4yBYiZ8v1bX2A==
   dependencies:
     "@babel/runtime" "^7.3.1"
 
@@ -7235,10 +7235,10 @@ react-error-overlay@5.1.6:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
   integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
 
-react-i18next@^10.11.3:
-  version "10.11.3"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-10.11.3.tgz#ceeae82177162b6ba0af162b5c355258cf4e5d0d"
-  integrity sha512-+kR0SQrTSws+NQfqK6Xe2FR6tMyfIPB6voxUqnLQ35Eh7T0vfe+v7eC4fF3pZlGGyn0qPKr294ACGbIz74u0sQ==
+react-i18next@^10.11.5:
+  version "10.11.5"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-10.11.5.tgz#10d0726a6c63c2d928078a7e7ec3db708246be04"
+  integrity sha512-+LXYehLGWbOzM4on9pgeCMTmo7J24Pm2rio4S8OSVdYudUKxLSYzoMDgJect0SQbTlIiK6b6+OTgTGY4YKPECw==
   dependencies:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"


### PR DESCRIPTION
Fix the following error when using WithTranslation interface 
```Property 't' does not exist on type 'Readonly<Props> & Readonly<{ children?: ReactNode; }>'.```

Typescript user need to be at least at version ``` 17.0.9``` from the README of the react-i18next library
https://github.com/i18next/react-i18next/blob/master/README.md#requirements