### PR TITLE
fix: add trailing slash to ignoreRoutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ MyPage.getInitialProps = async({ req }) => {
 | `browserLanguageDetection`  | `true`  |
 | `defaultNS` | `'common'`  |
 | `defaultLanguage`  | `'en'`  |
-| `ignoreRoutes`  | `['/_next', '/static']`  |
+| `ignoreRoutes`  | `['/_next/', '/static/']`  |
 | `otherLanguages` (required) | `[]`  |
 | `localeExtension` | `'json'`  |
 | `localePath` | `'static/locales'`  |

--- a/__tests__/middlewares/next-i18next-middleware.test.ts
+++ b/__tests__/middlewares/next-i18next-middleware.test.ts
@@ -72,7 +72,7 @@ describe('next-18next middleware', () => {
     expect(i18nextMiddleware.handle)
       .toBeCalledWith('i18n',
         expect.objectContaining({
-          ignoreRoutes: expect.arrayContaining(['/_next', '/static']),
+          ignoreRoutes: expect.arrayContaining(['/_next/', '/static/']),
         }))
   })
 

--- a/__tests__/test-i18next-config.ts
+++ b/__tests__/test-i18next-config.ts
@@ -8,7 +8,7 @@ export default {
     allLanguages: ['en', 'de'],
     defaultLanguage: 'en',
     otherLanguages: ['de'],
-    ignoreRoutes: ['/_next', '/static'],
+    ignoreRoutes: ['/_next/', '/static/'],
     serverLanguageDetection: true,
   },
 }

--- a/src/config/default-config.ts
+++ b/src/config/default-config.ts
@@ -22,7 +22,7 @@ const config = {
   },
   browserLanguageDetection: true,
   serverLanguageDetection: true,
-  ignoreRoutes: ['/_next', '/static'],
+  ignoreRoutes: ['/_next/', '/static/'],
   customDetectors: [],
   detection: {
     lookupCookie: 'next-i18next',


### PR DESCRIPTION
Lack of trailing slashes on the default config value for `ignoreRoutes` prevents loading of i18n for any routes that start with `/static`. Such as, for example: `my.blog.com/static-typing-is-cool`. This PR fixes this by adding trailing slashes.

Fixes #455.