### PR TITLE
fix: export `WithTranslation` props type for typescript

### DIFF
--- a/__tests__/types.test.tsx
+++ b/__tests__/types.test.tsx
@@ -10,7 +10,7 @@ import NextI18Next, {
   WithTranslation,
 } from '../types'
 
-const DummyComponent = () => <div />
+const DummyComponent: React.FC<{} & WithTranslation> = () => <div />
 
 const emptyConfig = {
   defaultLanguage: null,
@@ -21,4 +21,3 @@ const emptyConfig = {
 const Instance = new NextI18Next(emptyConfig)
 Instance.appWithTranslation(DummyComponent)
 Instance.withTranslation('common')(DummyComponent)
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { consoleMessage } from './utils'
 import { Link } from './components';
 import { wrapRouter } from './router';
 
-import { AppWithTranslation, Config, InitConfig, Trans as TransType, Link as LinkType, I18n, UseTranslation, WithTranslation, Router } from '../types'
+import { AppWithTranslation, Config, InitConfig, Trans as TransType, Link as LinkType, I18n, UseTranslation, WithTranslationHocType, Router } from '../types'
 
 export { withTranslation } from 'react-i18next'
 
@@ -20,7 +20,7 @@ export default class NextI18Next {
   readonly i18n: I18n;
   readonly config: Config;
   readonly useTranslation: UseTranslation;
-  readonly withTranslation: WithTranslation;
+  readonly withTranslation: WithTranslationHocType;
   readonly appWithTranslation: AppWithTranslation;
 
   readonly consoleMessage: () => void

--- a/types.d.ts
+++ b/types.d.ts
@@ -4,7 +4,8 @@ import * as React from 'react'
 import {
   useTranslation,
   TransProps,
-  withTranslation
+  withTranslation,
+  WithTranslation
 } from 'react-i18next'
 import { LinkProps } from 'next/link'
 import { SingletonRouter } from 'next/router'
@@ -39,6 +40,7 @@ export type AppWithTranslation = <P extends object>(Component: React.ComponentTy
 export type TFunction = i18next.TFunction
 export type I18n = i18next.i18n
 export type WithTranslationHocType = typeof withTranslation
+export type WithTranslation = WithTranslation
 
 declare class NextI18Next {
   constructor(config: InitConfig);

--- a/types.d.ts
+++ b/types.d.ts
@@ -38,7 +38,7 @@ export type UseTranslation = typeof useTranslation
 export type AppWithTranslation = <P extends object>(Component: React.ComponentType<P> | React.ElementType<P>) => any
 export type TFunction = i18next.TFunction
 export type I18n = i18next.i18n
-export type WithTranslation = typeof withTranslation
+export type WithTranslationHocType = typeof withTranslation
 
 declare class NextI18Next {
   constructor(config: InitConfig);
@@ -48,7 +48,7 @@ declare class NextI18Next {
   i18n: I18n
   config: Config
   useTranslation: UseTranslation
-  withTranslation: WithTranslation
+  withTranslation: WithTranslationHocType
   appWithTranslation: AppWithTranslation
 }
 


### PR DESCRIPTION
Fixes #360 

`WithTranslationHocType` is a new type that's used internally to type `withTranslation` HoC.It has been previously called `WithTranslation`.

That resulted in a name clash since `react-i18next` [exports its own `WithTranslation` interface](https://github.com/i18next/react-i18next/blob/master/src/index.d.ts#L69). This interface is the interface of the pros injected by `withTranslation` HoC (yes that naming is quite counter-intuitive). 

The issue was missed in the tests because the dummy component was not typed. 