### PR TITLE
fix(middleware): prevent removing subPath when not required

### DIFF
--- a/__tests__/middlewares/next-i18next-middleware.test.ts
+++ b/__tests__/middlewares/next-i18next-middleware.test.ts
@@ -137,5 +137,29 @@ describe('next-18next middleware', () => {
       expect(res.header).toHaveBeenNthCalledWith(3, 'Pragma', 'no-cache')
       expect(next).toBeCalledTimes(0)
     })
+
+    it('should not removes lang subpath from url when not required', () => {
+      const language = 'de'
+      const subpath = 'german'
+      const url = `/${subpath}page1`
+      req = {
+        url,
+        query: {},
+        i18n: {
+          ...testI18NextConfig,
+          options: {
+            ...testI18NextConfig.options,
+            localeSubpaths: {
+              [language]: subpath,
+            }
+          }
+        }
+      }
+
+      callAllMiddleware()
+
+      expect(req.url).toBe(url)
+      expect(next).toBeCalledTimes(1)
+    })
   })
 })

--- a/src/middlewares/next-i18next-middleware.ts
+++ b/src/middlewares/next-i18next-middleware.ts
@@ -79,7 +79,7 @@ export default function (nexti18next) {
         modify req.url in place so that NextJs will
         render the correct route
       */
-      if(lngFromCurrentSubpath !== undefined) {
+      if (typeof lngFromCurrentSubpath === 'string') {
         const params = localeSubpathRoute(req.url)
         if (params !== false) {
           const { subpath } = params

--- a/src/middlewares/next-i18next-middleware.ts
+++ b/src/middlewares/next-i18next-middleware.ts
@@ -1,15 +1,15 @@
+import { NextFunction, Request, Response } from 'express'
 import i18nextMiddleware from 'i18next-express-middleware'
-import { Request, Response, NextFunction } from 'express'
 import pathMatch from 'path-match'
 
 import {
-  redirectWithoutCache,
+  addSubpath,
   lngFromReq,
+  redirectWithoutCache,
   removeSubpath,
   subpathFromLng,
   subpathIsPresent,
   subpathIsRequired,
-  addSubpath,
 } from '../utils'
 
 const route = pathMatch()
@@ -79,11 +79,13 @@ export default function (nexti18next) {
         modify req.url in place so that NextJs will
         render the correct route
       */
-      const params = localeSubpathRoute(req.url)
-      if (params !== false) {
-        const { subpath } = params
-        req.query = { ...req.query, subpath, lng: currentLng }
-        req.url = removeSubpath(req.url, subpath)
+      if(lngFromCurrentSubpath !== undefined) {
+        const params = localeSubpathRoute(req.url)
+        if (params !== false) {
+          const { subpath } = params
+          req.query = { ...req.query, subpath, lng: currentLng }
+          req.url = removeSubpath(req.url, subpath)
+        }
       }
     }
 


### PR DESCRIPTION
This PR fixes #500 bug.
I've refactored middleware tests so the inner implementation won't be mocked.
It revealed an another bug, the `lng` query param is wrong when the page in one of the secondary langs