### PR TITLE
feat: Make shallowRender configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ After creating and exporting your `NextI18Next` instance, you need to take the f
 ```
 For more info, see [the NextJs section on custom servers](https://github.com/zeit/next.js#custom-server-and-routing).
 
+Note: You can pass `shallowRender: true` into config options to avoid triggering getInitialProps when `changeLanguage` method is invoked.
+
 That's it! Your app is ready to go. You can now use the `NextI18Next.withTranslation` HOC to make your components or pages translatable, based on namespaces:
 
 ```jsx
@@ -244,6 +246,7 @@ MyPage.getInitialProps = async({ req }) => {
 | `strictMode` | `true`  |
 | `use` (for plugins) | `[]`  |
 | `customDetectors` | `[]`  |
+| `shallowRender` | `false`  |
 
 _This table contains options which are specific to next-i18next. All other [i18next options](https://www.i18next.com/overview/configuration-options) can be passed in as well._
 

--- a/__tests__/config/create-config.test.ts
+++ b/__tests__/config/create-config.test.ts
@@ -81,6 +81,7 @@ describe('create configuration in non-production environment', () => {
 
       expect(config.backend.loadPath).toEqual('/home/user/static/locales/{{lng}}/{{ns}}.json')
       expect(config.backend.addPath).toEqual('/home/user/static/locales/{{lng}}/{{ns}}.missing.json')
+      expect(config.shallowRender).toEqual(false)
     })
 
     it('creates custom non-production configuration', () => {
@@ -191,6 +192,8 @@ describe('create configuration in non-production environment', () => {
 
       expect(config.backend.loadPath).toEqual('/static/translations/{{ns}}/{{lng}}.json')
       expect(config.backend.addPath).toEqual('/static/translations/{{ns}}/{{lng}}.missing.json')
+
+      expect(config.shallowRender).toEqual(true)
     })
 
     describe('localeExtension config option', () => {

--- a/__tests__/config/test-helpers.ts
+++ b/__tests__/config/test-helpers.ts
@@ -18,6 +18,7 @@ const userConfig = {
   localePath: 'static/translations',
   localeStructure: '{{ns}}/{{lng}}',
   localeSubpaths: localeSubpathVariations.FOREIGN,
+  shallowRender: true
 }
 
 const userConfigClientSide = {

--- a/__tests__/hocs/app-with-translation.test.tsx
+++ b/__tests__/hocs/app-with-translation.test.tsx
@@ -21,6 +21,7 @@ const defaultConfig = {
     wait: true,
     useSuspense: false,
   },
+  shallowRender: false
 }
 const defaultProps = {
   Component: () => (
@@ -86,5 +87,29 @@ describe('appWithTranslation', () => {
     (i18n as any).initializedLanguageOnce = false
     await i18n.changeLanguage('de')
     expect(mockRouterFn).toHaveBeenCalledTimes(0)
+  })
+
+  it('will call change language with shallow routing if shallowRender is true', async () => {
+    isServer.mockReturnValue(false)
+    const { i18n } = await createApp({ ...defaultConfig, shallowRender: true });
+    (i18n as any).initializedLanguageOnce = true
+    await i18n.changeLanguage('de')
+    expect(mockRouterFn).toHaveBeenCalledWith(
+      { "pathname": defaultProps.router.pathname, "query": {} },
+      defaultProps.router.pathname,
+      { shallow: true }
+    )
+  })
+
+  it('will not call change language with shallow routing if shallowRender is false', async () => {
+    isServer.mockReturnValue(false)
+    const { i18n } = await createApp();
+    (i18n as any).initializedLanguageOnce = true
+    await i18n.changeLanguage('de')
+    expect(mockRouterFn).toHaveBeenCalledWith(
+      { "pathname": defaultProps.router.pathname, "query": {} },
+      defaultProps.router.pathname,
+      { shallow: false }
+    )
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-i18next",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "repository": "git@github.com:isaachinman/next-i18next.git",
   "author": "Isaac Hinman <isaac@isaachinman.com>",
   "main": "dist/commonjs/index.js",

--- a/src/config/default-config.ts
+++ b/src/config/default-config.ts
@@ -37,6 +37,7 @@ const config = {
   },
   strictMode: true,
   errorStackTraceLimit: 0,
+  shallowRender: false,
   get initImmediate() {
     return !isServer()
   }

--- a/src/hocs/app-with-translation.tsx
+++ b/src/hocs/app-with-translation.tsx
@@ -43,7 +43,7 @@ export default function (WrappedComponent) {
 
           if (i18n.initializedLanguageOnce && typeof newLng === 'string' && prevLng !== newLng) {
             const { as, href } = lngPathCorrector(config, { as: asPath, href: routeInfo }, newLng)
-            router.replace(href, as)
+            router.replace(href, as, {shallow: config.shallowRender})
           }
         }
 

--- a/src/hocs/app-with-translation.tsx
+++ b/src/hocs/app-with-translation.tsx
@@ -43,7 +43,7 @@ export default function (WrappedComponent) {
 
           if (i18n.initializedLanguageOnce && typeof newLng === 'string' && prevLng !== newLng) {
             const { as, href } = lngPathCorrector(config, { as: asPath, href: routeInfo }, newLng)
-            router.replace(href, as, {shallow: config.shallowRender})
+            router.replace(href, as, { shallow: config.shallowRender })
           }
         }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -23,6 +23,7 @@ export type InitConfig = {
   localeSubpaths?: Record<string, string>;
   use?: any[];
   customDetectors?: any[];
+  shallowRender?: boolean;
 } & i18next.InitOptions
 
 export type Config = {


### PR DESCRIPTION
We wanted to make optional SSR when trigger changeLanguage method. So, we set ` shallowRender: false ` as a default value in `default-config.ts`. 

After this, users can set `shallowRender: true` in order to disable SSR on each changeLanguage method trigger.