### PR TITLE
feat: Make the as prop accept all kind of UrlLike or string

### DIFF
--- a/__tests__/utils/lng-path-corrector.test.ts
+++ b/__tests__/utils/lng-path-corrector.test.ts
@@ -35,7 +35,7 @@ describe('lngPathCorrector utility function', () => {
   it('throws if currentRoute.as is not undefined or a string', () => {
     currentRoute.as = 10
     expect(() => lngPathCorrector(config, currentRoute, 'en')).toThrowError(
-      '\'as\' type must be \'string\', but it is number',
+      '\'as\' type must be \'string\' or an \'object\', but it is number',
     )
   })
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/express": "^4.16.1",
     "@types/jest": "^24.0.16",
     "@types/jest-environment-puppeteer": "^4.0.0",
+    "@types/node": "^12.7.9",
     "@types/react": "^16.8.4",
     "@types/react-dom": "^16.8.2",
     "@typescript-eslint/eslint-plugin": "^1.13.0",

--- a/src/utils/lng-path-corrector.ts
+++ b/src/utils/lng-path-corrector.ts
@@ -1,4 +1,4 @@
-import { format as formatUrl, parse as parseUrl } from 'url'
+import { format as formatUrl, parse as parseUrl, UrlObject } from 'url'
 import { LinkProps } from 'next/link'
 
 import { Config } from '../../types'
@@ -8,6 +8,10 @@ import subpathFromLng from './subpath-from-lng'
 
 type As = LinkProps['as']
 type Href = LinkProps['href']
+interface Route {
+  href: Href;
+  as: As;
+}
 
 const parseAs = (originalAs, href): As => {
   const asType = typeof originalAs
@@ -24,7 +28,7 @@ const parseAs = (originalAs, href): As => {
   return as
 }
 
-const parseHref = (originalHref): Href => {
+const parseHref = (originalHref): UrlObject => {
   const hrefType = typeof originalHref
   let href
 
@@ -40,7 +44,7 @@ const parseHref = (originalHref): Href => {
   return href
 }
 
-export default (config: Config, currentRoute, currentLanguage): LinkProps => {
+export default (config: Config, currentRoute: Route, currentLanguage: string): LinkProps => {
   const { allLanguages, localeSubpaths } = config
   const { as: originalAs, href: originalHref } = currentRoute
 
@@ -63,7 +67,7 @@ export default (config: Config, currentRoute, currentLanguage): LinkProps => {
   */
   Object.values(localeSubpaths).forEach((subpath) => {
     if (typeof as === 'object') {
-      if (subpathIsPresent(as, subpath)) {
+      if (subpathIsPresent(as.pathname, subpath)) {
         as.pathname = removeSubpath(as.pathname, subpath)
       }
     } else if (typeof as === 'string') {
@@ -87,8 +91,12 @@ export default (config: Config, currentRoute, currentLanguage): LinkProps => {
       as = `/${subpath}${currentAs}`.replace(/\/$/, '')
     }
 
+    if (typeof href.query !== 'object') throw new Error(`'href.query' must be an object`)
+    if (!href.query) href.query = {}
+
+
     href.query.lng = currentLanguage
-    href.query.subpath = subpath
+    href.query.subpath = subpath || ''
   }
 
   return { as, href }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,6 +1278,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
   integrity sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==
 
+"@types/node@^12.7.9":
+  version "12.7.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.9.tgz#da0210f91096aa67138cf5afd04c4d629f8a406a"
+  integrity sha512-P57oKTJ/vYivL2BCfxCC5tQjlS8qW31pbOL6qt99Yrjm95YdHgNZwjrTTjMBh+C2/y6PXIX4oz253+jUzxKKfQ==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
Should fix #517

```tsx
<Link
  href='/somepage'
  as={{ pathname: '/test', hash: 'something', query: { page: 2 } }}
>
  Test
</Link>
```

will output now something like: 

```
http://localhost:3000/en/test?page=2#something
```