### PR TITLE
feat: Add option to configure client locale path

### DIFF
--- a/__tests__/config/create-config.test.ts
+++ b/__tests__/config/create-config.test.ts
@@ -189,8 +189,8 @@ describe('create configuration in non-production environment', () => {
 
       expect(config.ns).toEqual(['universal'])
 
-      expect(config.backend.loadPath).toEqual('/static/translations/{{ns}}/{{lng}}.json')
-      expect(config.backend.addPath).toEqual('/static/translations/{{ns}}/{{lng}}.missing.json')
+      expect(config.backend.loadPath).toEqual('/static/locales/{{ns}}/{{lng}}.json')
+      expect(config.backend.addPath).toEqual('/static/locales/{{ns}}/{{lng}}.missing.json')
     })
 
     describe('localeExtension config option', () => {

--- a/__tests__/config/test-helpers.ts
+++ b/__tests__/config/test-helpers.ts
@@ -22,9 +22,10 @@ const userConfig = {
 
 const userConfigClientSide = {
   ...userConfig,
+  clientLocalePath: 'static/locales',
   backend: {
-    loadPath: '/static/translations/{{ns}}/{{lng}}.json',
-    addPath: '/static/translations/{{ns}}/{{lng}}.missing.json',
+    loadPath: '/static/locales/{{ns}}/{{lng}}.json',
+    addPath: '/static/locales/{{ns}}/{{lng}}.missing.json',
   },
 }
 

--- a/src/config/create-config.ts
+++ b/src/config/create-config.ts
@@ -25,6 +25,7 @@ export default (userConfig) => {
     defaultLanguage,
     localeExtension,
     localePath,
+    clientLocalePath,
     localeStructure,
   } = combinedConfig
 
@@ -60,8 +61,8 @@ export default (userConfig) => {
 
     // Set client side backend
     combinedConfig.backend = {
-      loadPath: `/${localePath}/${localeStructure}.${localeExtension}`,
-      addPath: `/${localePath}/${localeStructure}.missing.${localeExtension}`,
+      loadPath: `/${clientLocalePath || localePath}/${localeStructure}.${localeExtension}`,
+      addPath: `/${clientLocalePath || localePath}/${localeStructure}.missing.${localeExtension}`,
     }
 
     combinedConfig.ns = [combinedConfig.defaultNS]


### PR DESCRIPTION
Currently the client locale path (server route that delivers a translation file) is assumed to be the same as the localePath option.

This PR provides allows us specify a custom path for it via the clientLocalePath option, which is optional.

For example I have a project with the following folder structure:
```
root
  - src // Folder where the next app resides
    - i18n.js
    - server.js
    - static
      - locales
        - en
        - fr
  - package.json
  - next.config.json
```

And this is where I initialize my `NextI18Next` instance:
```
// src/i18n.js

const NextI18NextInstance = new NextI18Next({
  defaultLanguage: 'en',
  otherLanguages: ['fr'],
  localePath: 'src/static/locales',
  // Optional
  clientLocalePath: 'static/locales'
})
```

Without the `clientLocalePath` option, the backend route that the client side would hit would be `/src/static/locales/{{ns}}/{{lng}}.json`

With the `clientLocalePath` option, we can add a custom path which in this case would be `/static/locales/{{ns}}/{{lng}}.json`.