### PR TITLE
fix: Use localeStructure to validate defaultNS in create-config

### DIFF
--- a/src/config/create-config.ts
+++ b/src/config/create-config.ts
@@ -36,7 +36,10 @@ export default (userConfig) => {
     // Validate defaultNS
     // https://github.com/isaachinman/next-i18next/issues/358
     if (process.env.NODE_ENV !== 'production' && typeof combinedConfig.defaultNS === 'string') {
-      const defaultNSPath = path.join(process.cwd(), `${localePath}/${defaultLanguage}/${combinedConfig.defaultNS}.${localeExtension}`)
+      const defaultLocaleStructure = localeStructure
+        .replace("{{lng}}", defaultLanguage)
+        .replace("{{ns}}", combinedConfig.defaultNS)
+      const defaultNSPath = path.join(process.cwd(), `${localePath}/${defaultLocaleStructure}.${localeExtension}`)
       const defaultNSExists = fs.existsSync(defaultNSPath)
       if (!defaultNSExists) {
         throw new Error(`Default namespace not found at ${defaultNSPath}`)


### PR DESCRIPTION
This shoud fix #496 

Just added a few lines that use `localeStructure` to determine `defaultNSPath` while checking if the translation file for the default NS and locale exists.

Right now, when defining a custom folder structure for locale files, the `create-config` won't use the `localeStructure` config variable, causing the code to throw an error.