### PR TITLE
fix: prevent warning in console in Firefox

### DIFF
--- a/src/utils/console-message.ts
+++ b/src/utils/console-message.ts
@@ -40,44 +40,37 @@ export default function createConsoleLog(messageType, message) {
 
   let util
 
-  if (!strictMode) {
-    return
-  }
-
-  if (process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV !== 'production' && strictMode) {
     util = require('util')
-  } else {
-    return
+    
+    /* Temporarily set the stacktrace to 0 or errorStackTraceLimit,
+       in order to only display a message */
+    (Error as any).errorStackTraceLimit = errorStackTraceLimit
+
+    // Make room for new message
+    console.log()
+
+    // Make sure the message is a string
+    if (typeof message !== 'string') {
+      const metaError = new Error()
+      metaError.name = 'Meta'
+      metaError.message = `Param message needs to be of type: string. Instead, '${typeof message}' was provided.\n
+  ------------------------------------------------\n
+  \u200b
+          The provided ${typeof message}:\n
+  \u200b
+            ${util.inspect(message, true, 8, true)}
+  \u200b
+  ------------------------------------------------\n
+      `
+      console.error(metaError)
+      return
+    }
+
+    // Log the message to console
+    logMessage(messageType, message)
   }
-
-  /* Temporarily set the stacktrace to 0 or errorStackTraceLimit,
-     in order to only display a message */
-  (Error as any).errorStackTraceLimit = errorStackTraceLimit
-
-  // Make room for new message
-  console.log()
-
-  // Make sure the message is a string
-  if (typeof message !== 'string') {
-    const metaError = new Error()
-    metaError.name = 'Meta'
-    metaError.message = `Param message needs to be of type: string. Instead, '${typeof message}' was provided.\n
-------------------------------------------------\n
-\u200b
-        The provided ${typeof message}:\n
-\u200b
-          ${util.inspect(message, true, 8, true)}
-\u200b
-------------------------------------------------\n
-    `
-    console.error(metaError)
-    return
-  }
-
-  // Log the message to console
-  logMessage(messageType, message)
-
+ 
   // Reset stack limit
   Error.stackTraceLimit = prevStackLimit
-
 }


### PR DESCRIPTION
Just restructure the code a bit to prevent the “Inaccessible code after return statement” warning in Firefox (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Stmt_after_return)