### PR TITLE
Remove setting stackTraceLimit before checks in createConsoleLog

### DIFF
--- a/src/utils/console-message.ts
+++ b/src/utils/console-message.ts
@@ -36,7 +36,6 @@ export default function createConsoleLog(messageType, message) {
   const { errorStackTraceLimit, strictMode } = this.config
 
   const prevStackLimit = Error.stackTraceLimit
-  Error.stackTraceLimit = errorStackTraceLimit
 
   let util
 


### PR DESCRIPTION
fixes #550 