### PR TITLE
fix error if pathname is not valid in subpathIsPresent

### DIFF
--- a/src/utils/subpath-is-present.ts
+++ b/src/utils/subpath-is-present.ts
@@ -6,6 +6,7 @@ export default (url: string, subpath: string) => {
   }
 
   const { pathname } = parseUrl(url)
+  if (!pathname) return false
   return (
     (pathname.length === subpath.length + 1 && pathname === `/${subpath}`) ||
     (pathname.startsWith(`/${subpath}/`))


### PR DESCRIPTION
when use <Link href="#"> got error `Cannot read property 'length' of null` in subpath-is-present.ts file
So i return false if pathname is not valid.