### PR TITLE
fix: Typescript declaration conflict error

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -5,7 +5,7 @@ import {
   useTranslation,
   TransProps,
   withTranslation,
-  WithTranslation
+  WithTranslation as ReactI18nextWithTranslation
 } from 'react-i18next'
 import { LinkProps } from 'next/link'
 import { SingletonRouter } from 'next/router'
@@ -40,7 +40,7 @@ export type AppWithTranslation = <P extends object>(Component: React.ComponentTy
 export type TFunction = i18next.TFunction
 export type I18n = i18next.i18n
 export type WithTranslationHocType = typeof withTranslation
-export type WithTranslation = WithTranslation
+export type WithTranslation = ReactI18nextWithTranslation
 
 declare class NextI18Next {
   constructor(config: InitConfig);


### PR DESCRIPTION
Fix [#574](https://github.com/isaachinman/next-i18next/issues/574).

It was caused by this breaking change in typescript 3.7 
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#local-and-imported-type-declarations-now-conflict

If the `skipLibCheck` in tsconfig.json is `false`, the compile-time error `Import declaration conflicts with local declaration of 'WithTranslation'.` will be thrown.