### PR TITLE
Simple Example With Now

### DIFF
--- a/examples/simple/.env
+++ b/examples/simple/.env
@@ -1,0 +1,1 @@
+LOCALE_SUBPATHS=all

--- a/examples/simple/i18n.js
+++ b/examples/simple/i18n.js
@@ -4,7 +4,6 @@
 */
 
 const NextI18Next = require('next-i18next').default
-const { localeSubpaths } = require('next/config').default().publicRuntimeConfig
 
 const localeSubpathVariations = {
   none: {},
@@ -18,6 +17,7 @@ const localeSubpathVariations = {
 }
 
 module.exports = new NextI18Next({
+  defaultLanguage: 'en',
   otherLanguages: ['de'],
-  localeSubpaths: localeSubpathVariations[localeSubpaths],
+  localeSubpaths: localeSubpathVariations[process.env.LOCALE_SUBPATHS],
 })

--- a/examples/simple/next.config.js
+++ b/examples/simple/next.config.js
@@ -1,7 +1,10 @@
+require('dotenv').config()
+
 module.exports = {
-  publicRuntimeConfig: {
-    localeSubpaths: typeof process.env.LOCALE_SUBPATHS === 'string'
-      ? process.env.LOCALE_SUBPATHS
-      : 'none',
+  webpack: (config) => {
+    return config
   },
+  env: {
+    LOCALE_SUBPATHS: typeof process.env.LOCALE_SUBPATHS === 'string' ? process.env.LOCALE_SUBPATHS : 'none'
+  }
 }

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -13,11 +13,12 @@
   },
   "devDependencies": {},
   "dependencies": {
+    "dotenv": "^8.2.0",
     "express": "^4.16.4",
     "i18next": "^14.0.1",
     "next": "^9.0.3",
-    "next-i18next": "link:../../",
-    "react": "link:../../node_modules/react",
-    "react-dom": "link:../../node_modules/react-dom"
+    "next-i18next": "^2.1.1",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
   }
 }


### PR DESCRIPTION
- Modify `examples/simple/package.json` to remove `yarn link` to work with Now build and deploy
- Add `dotenv` package to use with `webpack` in `next.config.js` and setup environment variables so that we no longer use `publicRuntimeConfig` per the NextJS documentation suggestion
- Create `.env` file with `LOCALE_SUBPATHS` environment variable to be referenced in `next.config.js`
- Modify `i18n.js` to reference environment variables instead of runtime configuration

After this work I run `now` within the `examples/simple` directory and it builds and deploys successfully, but the following error is shown at the site url.

```
502: BAD_GATEWAY
Code: NO_STATUS_CODE_FROM_FUNCTION
ID: `oma1:m8p7z-1574916256454-fc586ea27354`
```

Along with that error the following error is shown in the Now logs.

```
2019-11-28T04:44:18.065Z	undefined	ERROR	Uncaught Exception 	{"errorType":"Error","errorMessage":"ENOENT: no such file or directory, scandir '/var/task/static/locales/en'","code":"ENOENT","errno":-2,"syscall":"scandir","path":"/var/task/static/locales/en","stack":["Error: ENOENT: no such file or directory, scandir '/var/task/static/locales/en'","    at Object.readdirSync (fs.js:854:3)","    at getAllNamespaces (/var/task/.next/serverless/pages/_error.js:7824:19)","    at _default (/var/task/.next/serverless/pages/_error.js:7829:27)","    at new NextI18Next (/var/task/.next/serverless/pages/_error.js:8790:46)","    at Object.k7Sn (/var/task/.next/serverless/pages/_error.js:7877:18)","    at __webpack_require__ (/var/task/.next/serverless/pages/_error.js:23:31)","    at Module.Y0NT (/var/task/.next/serverless/pages/_error.js:3617:63)","    at __webpack_require__ (/var/task/.next/serverless/pages/_error.js:23:31)","    at Module.DISn (/var/task/.next/serverless/pages/_error.js:1251:85)","    at __webpack_require__ (/var/task/.next/serverless/pages/_error.js:23:31)"]}END RequestId: 36487a46-a65c-4f02-8c78-6c6649f2c8b5
```