### PR TITLE
feat: Add initPromise to NextI18Next class

### DIFF
--- a/__tests__/create-i18next-client.test.ts
+++ b/__tests__/create-i18next-client.test.ts
@@ -5,7 +5,7 @@ import createI18nextClient from '../src/create-i18next-client'
 const i18nextMiddleware = require('i18next-express-middleware')
 
 jest.mock('i18next', () => ({
-  init: jest.fn(),
+  init: jest.fn(() => new Promise(resolve => setTimeout(() => resolve(), 0))),
   use: jest.fn(),
 }))
 
@@ -24,6 +24,15 @@ describe('initializing i18n', () => {
     (i18next.init as jest.Mock).mockClear();
     (i18next.use as jest.Mock).mockClear()
     i18nextMiddleware.LanguageDetector.mockClear()
+  })
+
+  it('should return both the i18n object and an initPromise', async () => {
+    const { i18n, initPromise } = createI18nextClient({
+      use: [],
+      customDetectors: [],
+    })
+    expect(typeof i18n.isInitialized).toBe('boolean')
+    expect(typeof initPromise.then).toBe('function')
   })
 
   it('should not initialize i18n if i18n is already initialized', () => {

--- a/__tests__/types.test.tsx
+++ b/__tests__/types.test.tsx
@@ -5,6 +5,7 @@ import NextI18Next, {
   AppWithTranslation,
   Config,
   I18n,
+  InitPromise,
   InitConfig,
   TFunction,
   WithTranslation,

--- a/examples/simple/server.js
+++ b/examples/simple/server.js
@@ -12,6 +12,7 @@ const handle = app.getRequestHandler();
   await app.prepare()
   const server = express()
 
+  await nextI18next.initPromise
   server.use(nextI18NextMiddleware(nextI18next))
 
   server.get('*', (req, res) => handle(req, res))

--- a/examples/simple/yarn.lock
+++ b/examples/simple/yarn.lock
@@ -2800,10 +2800,10 @@ i18next@^14.0.1:
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-14.1.1.tgz#d569aff68c088151f09fcb0cb6f44b36d62731d3"
   integrity sha512-HItn9RHLyrDqe6pw6qXMYHGPHNc3y1FZndJfBlD6k4sRS0FAlYLvqCDVIWFc1XultBgsv348TtvL/lleG6JgBg==
 
-i18next@^18.0.1:
-  version "18.0.1"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-18.0.1.tgz#10841209f6983df4d8e367204da403d8cbc609cf"
-  integrity sha512-KWd9qMFXw0qjxF7cTAqQselPCYoHfaLvBs8c6JcNzaQKVxbAlE/wv9EZXPy+JlKUcXCT0qgjcmxrJjmbnEp60A==
+i18next@^19.0.3:
+  version "19.0.3"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.0.3.tgz#31fd3165762d9802e08a2a86932db4eff5c862e9"
+  integrity sha512-Ru4afr++b4cUApsIBifcMYyWG9Nx8wlFdq4DuOF+UuoPoQKfuh0iAVMekTjs6w1CZLUOVb5QZEuoYRLmu17EIA==
   dependencies:
     "@babel/runtime" "^7.3.1"
 

--- a/src/create-i18next-client.ts
+++ b/src/create-i18next-client.ts
@@ -3,7 +3,11 @@ import i18n from 'i18next'
 import i18nextXHRBackend from 'i18next-xhr-backend'
 import I18nextBrowserLanguageDetector from 'i18next-browser-languagedetector'
 
+import { InitPromise } from '../types'
+
 export default (config) => {
+  let initPromise: InitPromise
+
   if (!i18n.isInitialized) {
 
     if (isNode) {
@@ -25,8 +29,8 @@ export default (config) => {
     }
 
     config.use.forEach(x => i18n.use(x))
-    i18n.init(config)
+    initPromise = i18n.init(config)
 
   }
-  return i18n
+  return { i18n, initPromise }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { consoleMessage } from './utils'
 import { Link } from './components'
 import { wrapRouter } from './router'
 
-import { AppWithTranslation, Config, InitConfig, Trans as TransType, Link as LinkType, I18n, UseTranslation, WithTranslationHocType, Router } from '../types'
+import { AppWithTranslation, Config, InitConfig, Trans as TransType, Link as LinkType, I18n, InitPromise, UseTranslation, WithTranslationHocType, Router } from '../types'
 
 export { withTranslation } from 'react-i18next'
 
@@ -18,6 +18,7 @@ export default class NextI18Next {
   readonly Link: LinkType
   readonly Router: Router
   readonly i18n: I18n
+  readonly initPromise: InitPromise
   readonly config: Config
   readonly useTranslation: UseTranslation
   readonly withTranslation: WithTranslationHocType
@@ -38,7 +39,10 @@ export default class NextI18Next {
       throw new Error('next-i18next has upgraded to react-i18next v10 - please rename withNamespaces to withTranslation.')
     }
 
-    this.i18n = createI18NextClient(this.config)
+    const { i18n, initPromise } = createI18NextClient(this.config)
+    this.i18n = i18n
+    this.initPromise = initPromise
+
     this.appWithTranslation = appWithTranslation.bind(this)
     this.withTranslation = (namespace, options) => Component => hoistNonReactStatics(
       withTranslation(namespace, options)(Component), Component)

--- a/types.d.ts
+++ b/types.d.ts
@@ -46,6 +46,7 @@ export type TFunction = I18NextTFunction
 export type I18n = i18n
 export type WithTranslationHocType = typeof withTranslation
 export type WithTranslation = ReactI18nextWithTranslation
+export type InitPromise = Promise<TFunction>
 
 declare class NextI18Next {
   constructor(config: InitConfig);
@@ -53,6 +54,7 @@ declare class NextI18Next {
   Link: Link
   Router: Router
   i18n: I18n
+  initPromise: InitPromise
   config: Config
   useTranslation: UseTranslation
   withTranslation: WithTranslationHocType


### PR DESCRIPTION
Adds an `initPromise` property to the NextI18Next class which can then be awaited if desired:

```jsx
await nextI18next.initPromise
server.use(nextI18NextMiddleware(nextI18next))
```

Fixes #564.