### PR TITLE
docs: explicit the need for `getInitialProps` for stateless app

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ It's recommended to export this `NextI18Next` instance from a single file in you
 
 After creating and exporting your `NextI18Next` instance, you need to take the following steps to get things working:
 
-1. Create an `_app.js` file inside your `pages` directory, and wrap it with the `NextI18Next.appWithTranslation` higher order component (HOC). You can see this approach in the [examples/simple/pages/_app.js](./examples/simple/pages/_app.js). 
+1. Create an `_app.js` file inside your `pages` directory, and wrap it with the `NextI18Next.appWithTranslation` higher order component (HOC). You can see this approach in the [examples/simple/pages/_app.js](./examples/simple/pages/_app.js).
+Your app component must either extend `App` if it's a class component or define a `getInitialProps` if it's a function component [(explanation here)](https://github.com/isaachinman/next-i18next/issues/615#issuecomment-575578375).
 2. Create a `server.js` file inside your root directory, initialise an [express](https://www.npmjs.com/package/express) server, and use the `nextI18NextMiddleware` middleware with your `nextI18Next` instance passed in. You can see this approach in the [examples/simple/server.js](./examples/simple/server.js).
 3. Update the scripts in `package.json` to:
 ```


### PR DESCRIPTION
It's a trap for new users. It is not immediate [in Next official doc for custom app](https://nextjs.org/docs/advanced-features/custom-app) that we need to add `getInitialProps` for i18n, all the more that it disable automatic static optimization (it frightens beginners to uncomment the code :) )