### PR TITLE
chore: move @types/express to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
-    "@types/express": "^4.16.1",
     "@types/jest": "^24.0.16",
     "@types/jest-environment-puppeteer": "^4.0.0",
     "@types/react": "^16.8.4",
@@ -100,6 +99,7 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
+    "@types/express": "^4.16.1",
     "core-js": "^2",
     "detect-node": "^2.0.4",
     "hoist-non-react-statics": "^3.2.0",


### PR DESCRIPTION
We currently use this package within a package that is consumed by our applications through a shared runtime package (fig 1). Therefore our applications are not fond of `express` or `next` and don't include any types. 

During the build process, Typescript will throw an error (fig 2) saying it can't find the types of `express` and advises us to install them.

```
// fig 1
// simplified dependency tree w/o node_modules/ directory
app-one
 └── next-runtime
  └── our-i18n-lib/
   └── next-i18next

app-two
 └── next-runtime
  └── our-i18n-lib/
   └── next-i18next
```
```
// fig 2
../../../node_modules/next-i18next/types.d.ts:11:25 - error TS7016: Could not find a declaration file for module 'express'. '/.../app-one/node_modules/express/index.js' implicitly has an 'any' type.
  Try `npm install @types/express` if it exists or add a new declaration (.d.ts) file containing `declare module 'express';`

11 import { Request } from 'express'
                           ~~~~~~~~~
```
After digging into this issue, we concluded that `@types/express` should be a regular dependency instead of a dev dependency.

The following two discussions do explain the reasons behind that:
- https://github.com/apollographql/apollo-client/issues/713
- https://github.com/microsoft/types-publisher/issues/81

I published a fork of this package with `@types/express` as regular dependencies for testing purposes here: https://www.npmjs.com/package/next-i18next_express-types 