### PR TITLE
feat: allow config.otherLanguages to be empty

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,6 @@ export default class NextI18Next {
     this.consoleMessage = consoleMessage.bind(this)
 
     /* Validation */
-    if (this.config.otherLanguages.length <= 0) {
-      throw new Error('To properly initialise a next-i18next instance you must provide one or more locale codes in config.otherLanguages.')
-    }
     this.withNamespaces = () => {
       throw new Error('next-i18next has upgraded to react-i18next v10 - please rename withNamespaces to withTranslation.')
     }


### PR DESCRIPTION
fixes #606.

There are others who have requested it plus i18next does work without such a check - why a library/plugin like next-i18next would add such a "validation" without a real need doesn't make much sense to me. 
Anyhow, simple to fix. Thanks for making next-i18next 🙂 