### PR TITLE
Define res.locals before executing other middlewares

### DIFF
--- a/src/middlewares/next-i18next-middleware.ts
+++ b/src/middlewares/next-i18next-middleware.ts
@@ -18,7 +18,11 @@ export default function (nexti18next) {
   const isI18nRoute = (req: Request) => ignoreRoutes.every(x => !req.url.startsWith(x))
 
   const middleware = []
-
+  
+  middleware.push((req: NextI18NextRequest, res: Response, next: NextFunction) => {
+    if (!res.locals) res.locals = {} // mimic Express res.locals
+    next()
+  })
   /*
     If not using server side language detection,
     we need to manually set the language for


### PR DESCRIPTION
Note: I'd rather see this issue fixed in `i18next-http-middleware` https://github.com/i18next/i18next-http-middleware/issues/15
But I post an alternative here just in case it's refused.

Basically, adding variables to `res.locals` is an Express convention. But in Next, `res.locals` seems to be undefined in some context, at least for me in development it is set but not in production.
I've tried to track down who sets this variable in dev (another package I use? Next? Idk) without success.

If `res.locals` is not defined, `http-middleware` won't provide you the various information about language, useful to set the `html` `lang` attribute for instance.