### PR TITLE
fix: I18nContext exported as type

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "i18next-http-middleware": "^3.0.2",
     "path-match": "^1.2.4",
     "prop-types": "^15.6.2",
-    "react-i18next": "^11.7.0",
+    "react-i18next": "^11.7.3",
     "url": "^0.11.0"
   },
   "peerDependencies": {

--- a/types.d.ts
+++ b/types.d.ts
@@ -45,13 +45,17 @@ export type Trans = (props: TransProps) => any
 export type Link = React.ComponentClass<LinkProps>
 export type Router = SingletonRouter
 export type UseTranslation = typeof useTranslation
-export type I18nContext = typeof I18nContext
 export type AppWithTranslation = <P extends object>(Component: React.ComponentType<P> | React.ElementType<P>) => any
 export type TFunction = I18NextTFunction
 export type I18n = i18n
 export type WithTranslationHocType = typeof withTranslation
 export type WithTranslation = ReactI18nextWithTranslation
 export type InitPromise = Promise<TFunction>
+
+export {
+  I18nContext,
+  withTranslation,
+}
 
 declare class NextI18Next {
   constructor(config: InitConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7957,10 +7957,10 @@ react-error-overlay@5.1.6:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
   integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
 
-react-i18next@^11.7.0:
-  version "11.7.0"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.7.0.tgz#f27c4c237a274e007a48ac1210db83e33719908b"
-  integrity sha512-8tvVkpuxQlubcszZON+jmoCgiA9gCZ74OAYli9KChPhETtq8pJsANBTe9KRLRLmX3ubumgvidURWr0VvKz1tww==
+react-i18next@^11.7.3:
+  version "11.7.3"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.7.3.tgz#256461c46baf5b3208c3c6860ca4e569fc7ed053"
+  integrity sha512-7sYZqVZgdaS9Z0ZH6nuJFErCD0zz5wK3jR4/xCrWjZcxHHF3GRu7BXdicbSPprZV4ZYz7LJzxxMHO7dg5Qb70A==
   dependencies:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"


### PR DESCRIPTION
I18nContext is exported as type instead of
value, typescript would complain when it is
used as value.

This commit:
- manually creates the type for context and export it
  as upstream `react-i18next` also has incorrect types
- export `withTranslation` as it is exported in index
- add a demo page for I18nContext in example

Fix #789