### PR TITLE
fix: sample i18n.js file throws error

### DIFF
--- a/examples/simple/i18n.js
+++ b/examples/simple/i18n.js
@@ -1,9 +1,10 @@
 const NextI18Next = require('next-i18next').default
-const { localeSubpaths } = require('next/config').default().publicRuntimeConfig
-const path = require('path')
+const Path = require('path')
 
 module.exports = new NextI18Next({
   otherLanguages: ['de'],
-  localeSubpaths,
-  localePath: path.resolve('./public/static/locales')
+  localeSubpaths, {
+    de: 'de'
+  },
+  localePath: Path.resolve('./public/static/locales')
 })


### PR DESCRIPTION
Using the sample `i18n.js` file throws this error due to the fact that `const { localeSubpaths } = require('next/config').default().publicRuntimeConfig` is undefined. 

```bash
web_1        | TypeError: Cannot read property 'en' of undefined
web_1        |     at subpathFromLng (/app/node_modules/next-i18next/dist/commonjs/utils/subpath-from-lng.js:13:38)
web_1        |     at /app/node_modules/next-i18next/dist/commonjs/middlewares/next-i18next-middleware.js:61:57
web_1        |     at /app/node_modules/next-i18next/dist/commonjs/hocs/app-with-translation.js:249:38
web_1        |     at new Promise (<anonymous>)
web_1        |     at _loop$ (/app/node_modules/next-i18next/dist/commonjs/hocs/app-with-translation.js:248:36)
web_1        |     at tryCatch (/app/node_modules/regenerator-runtime/runtime.js:63:40)
web_1        |     at Generator.invoke [as _invoke] (/app/node_modules/regenerator-runtime/runtime.js:293:22)
web_1        |     at Generator.next (/app/node_modules/regenerator-runtime/runtime.js:118:21)
web_1        |     at tryCatch (/app/node_modules/regenerator-runtime/runtime.js:63:40)
web_1        |     at maybeInvokeDelegate (/app/node_modules/regenerator-runtime/runtime.js:356:18)
```