### PR TITLE
feat: allow to use different locale paths for server and client

### DIFF
--- a/src/config/create-config.ts
+++ b/src/config/create-config.ts
@@ -34,11 +34,19 @@ export const createConfig = (userConfig) => {
     localeStructure,
   } = combinedConfig
 
+  let {
+    serverLocalePath,
+    clientLocalePath,
+  } = combinedConfig
+
   if (isServer()) {
 
     const fs = eval("require('fs')")
     const path = require('path')
-    let serverLocalePath = localePath
+
+    if (!serverLocalePath) {
+      serverLocalePath = localePath
+    }
 
     /*
       Validate defaultNS
@@ -46,7 +54,7 @@ export const createConfig = (userConfig) => {
     */
     if (typeof combinedConfig.defaultNS === 'string') {
       const defaultFile = `/${defaultLanguage}/${combinedConfig.defaultNS}.${localeExtension}`
-      const defaultNSPath = path.join(localePath, defaultFile)
+      const defaultNSPath = path.join(serverLocalePath, defaultFile)
       const defaultNSExists = fs.existsSync(defaultNSPath)
       if (!defaultNSExists) {
 
@@ -85,7 +93,9 @@ export const createConfig = (userConfig) => {
 
   } else {
 
-    let clientLocalePath = localePath
+    if (!clientLocalePath) {
+      clientLocalePath = localePath
+    }
     
     /*
       Remove public prefix from client site config


### PR DESCRIPTION
This is a small PR which allows user to specify different path for client and server scenarios. This allows for more flexible folder structure of the nextjs app, as sometimes just removing the `/public/` portion of the path isn't enough. For example having the nextjs app under `src` folder, as result of using custom server, this way the clientLocalePath would be `./public/static/locales` and the serverLocalePath `./src/public/static/locales`.