### PR TITLE
fix: allow fallbackLng to be set to false

### DIFF
--- a/src/config/create-config.ts
+++ b/src/config/create-config.ts
@@ -118,7 +118,7 @@ export const createConfig = (userConfig) => {
   /*
     Set fallback language to defaultLanguage in production
   */
-  if (!userConfig.fallbackLng) {
+  if (userConfig.fallbackLng === undefined) {
     combinedConfig.fallbackLng = process.env.NODE_ENV === 'production'
       ? combinedConfig.defaultLanguage
       : false

--- a/src/config/create-config.ts
+++ b/src/config/create-config.ts
@@ -118,7 +118,7 @@ export const createConfig = (userConfig) => {
   /*
     Set fallback language to defaultLanguage in production
   */
-  if (userConfig.fallbackLng === undefined) {
+  if (typeof userConfig.fallbackLng !== 'boolean' && !userConfig.fallbackLng) {
     combinedConfig.fallbackLng = process.env.NODE_ENV === 'production'
       ? combinedConfig.defaultLanguage
       : false


### PR DESCRIPTION
Setting fallback language to defaultLanguage in production should only occur if the developer didn't specifically set it to `false`, since that would be a valid config for i18next.

This fix will make it possible to avoid loading any fallback translation files, which could speed up page load.