### PR TITLE
feat: Add setting of language via pageProps

### DIFF
--- a/src/hocs/app-with-translation.tsx
+++ b/src/hocs/app-with-translation.tsx
@@ -17,6 +17,7 @@ interface Props {
 interface WrappedComponentProps {
   pageProps: {
     namespacesRequired?: string[];
+    lang?: string;
   };
 }
 
@@ -101,12 +102,20 @@ export const appWithTranslation = function (WrappedComponent) {
         )
       }
 
+      /* 
+        Load language for specific page if set in pageProps 
+      */
+      const pageLanguage = wrappedComponentProps.pageProps.lang
+
       /*
         Step 1: Determine initial language
       */
       if (req && req.i18n) {
 
         initialLanguage = lngFromReq(req)
+        if (pageLanguage) {
+          initialLanguage = pageLanguage
+        }
 
         /*
           Perform a lang change in case we're not on the right lang
@@ -115,6 +124,14 @@ export const appWithTranslation = function (WrappedComponent) {
 
       } else if (Array.isArray(i18n.languages) && i18n.languages.length > 0) {
         initialLanguage = i18n.language
+
+        /*
+          Perform a lang change in case the page language is different
+        */
+        if (pageLanguage && initialLanguage !== pageLanguage) {
+          initialLanguage = pageLanguage
+          await i18n.changeLanguage(initialLanguage)
+        }
       }
 
       /*


### PR DESCRIPTION
Added a feature to allow the defaultLanguage for a specific page to be set through a "lang" prop. This can be passed through getInitialProps.

I understand that this is not the direction that next. js is looking to go towards, but this (or a similar mechanism) is necessary for the localization of URLs, which still play a role in SEO.

Let me know if you need any changes to the implementation or the formatting.