### PR TITLE
fix: TS issues for v8-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:examples/simple": "yarn --cwd examples/simple && yarn --cwd examples/simple build",
     "prepublishOnly": "yarn build",
     "run-example": "yarn build && cd examples/simple && yarn && yarn dev",
-    "run-example:prod": "yarn --cwd examples/simple start",
+    "run-example:prod": "yarn build:examples/simple && yarn --cwd examples/simple start",
     "test": "yarn check-types && yarn clean && yarn build:cjs && yarn build:examples/simple && bundlesize && NODE_ENV=test jest --passWithNoTests --maxWorkers=1 --silent",
     "contributors:check": "all-contributors check",
     "contributors:add": "all-contributors add",

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -12,7 +12,7 @@ type AppProps = {
   pageProps: SSRConfig;
 }
 
-export const appWithTranslation = (WrappedComponent: React.ComponentType): React.ComponentType => {
+export const appWithTranslation = <P extends Record<string, unknown>>(WrappedComponent: React.ComponentType | React.ElementType): React.ComponentType<P> | React.ElementType<P> => {
   const AppWithTranslation = (props: AppProps) => {
     let i18n = null
     let locale = null

--- a/types.d.ts
+++ b/types.d.ts
@@ -9,6 +9,7 @@ import {
   WithTranslation as ReactI18nextWithTranslation
 } from 'react-i18next'
 import { InitOptions, i18n, TFunction as I18NextTFunction } from 'i18next'
+import { appWithTranslation } from './src';
 
 export type InitConfig = {
   strictMode?: boolean;
@@ -38,7 +39,7 @@ export type NextI18NextInternals = {
 
 export type Trans = (props: TransProps) => any
 export type UseTranslation = typeof useTranslation
-export type AppWithTranslation = <P extends unknown>(Component: React.ComponentType<P> | React.ElementType<P>) => any
+export type AppWithTranslation = typeof appWithTranslation
 export type TFunction = I18NextTFunction
 export type I18n = i18n
 export type WithTranslationHocType = typeof withTranslation
@@ -59,6 +60,7 @@ export type SSRConfig = {
 
 export {
   I18nContext,
+  appWithTranslation,
   useTranslation,
   withTranslation,
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -64,16 +64,3 @@ export {
   useTranslation,
   withTranslation,
 }
-
-declare class NextI18Next {
-  constructor(config: InitConfig);
-  Trans: Trans
-  i18n: I18n
-  initPromise: InitPromise
-  config: Config
-  useTranslation: UseTranslation
-  withTranslation: WithTranslationHocType
-  appWithTranslation: AppWithTranslation
-}
-
-export default NextI18Next


### PR DESCRIPTION
- fixes #907 by exposing `appWithTranslation` type
- changes `appWithTranslation` type signature: param is a React Component, not a React Component instance
~~- adds a Next.js example to typescript~~
- fixes the `run-example:prod` script by adding the `build` step before it