### PR TITLE
fix: Remove server side code from client bundle

### DIFF
--- a/src/config/createConfig.ts
+++ b/src/config/createConfig.ts
@@ -1,5 +1,5 @@
 import { defaultConfig } from './defaultConfig'
-import { consoleMessage, isServer } from '../utils'
+import { consoleMessage } from '../utils'
 import { Config } from '../../types'
 
 const deepMergeObjects = ['backend', 'detection']
@@ -21,7 +21,7 @@ export const createConfig = (userConfig: Config): Config => {
     localeStructure,
   } = combinedConfig
 
-  /** 
+  /**
    * Skips translation file resolution while in cimode
    * https://github.com/isaachinman/next-i18next/pull/851#discussion_r503113620
   */
@@ -29,16 +29,16 @@ export const createConfig = (userConfig: Config): Config => {
     return combinedConfig as Config
   }
 
-  if (isServer()) {
+  if (!process.browser) {
     combinedConfig.preload = [lng]
 
     const hasCustomBackend = userConfig.use && userConfig.use.find((b) => b.type === 'backend')
 
     if (!hasCustomBackend) {
-      const fs = eval("require('fs')")
+      const fs = require('fs')
       const path = require('path')
       let serverLocalePath = localePath
-  
+
       /*
         Validate defaultNS
         https://github.com/isaachinman/next-i18next/issues/358
@@ -48,14 +48,14 @@ export const createConfig = (userConfig: Config): Config => {
         const defaultNSPath = path.join(localePath, defaultFile)
         const defaultNSExists = fs.existsSync(defaultNSPath)
         if (!defaultNSExists) {
-  
+
           /*
             If defaultNS doesn't exist, try to fall back to the deprecated static folder
             https://github.com/isaachinman/next-i18next/issues/523
           */
           const staticDirPath = path.resolve(process.cwd(), STATIC_LOCALE_PATH, defaultFile)
           const staticDirExists = fs.existsSync(staticDirPath)
-  
+
           if (staticDirExists) {
             consoleMessage('warn', 'next-i18next: Falling back to /static folder, deprecated in next@9.1.*', combinedConfig)
             serverLocalePath = STATIC_LOCALE_PATH
@@ -84,7 +84,7 @@ export const createConfig = (userConfig: Config): Config => {
   } else {
 
     let clientLocalePath = localePath
-    
+
     /*
       Remove public prefix from client site config
     */

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -1,5 +1,3 @@
-import { isServer } from '../utils'
-
 const DEFAULT_LOCALE = 'en'
 const LOCALES = ['en']
 const DEFAULT_NAMESPACE = 'common'
@@ -30,6 +28,6 @@ export const defaultConfig = {
   errorStackTraceLimit: 0,
   shallowRender: false,
   get initImmediate(): boolean {
-    return !isServer()
+    return process.browser
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,1 @@
 export { consoleMessage } from './consoleMessage'
-export { isServer } from './isServer'

--- a/src/utils/isServer.ts
+++ b/src/utils/isServer.ts
@@ -1,1 +1,0 @@
-export const isServer = (): boolean => typeof window === 'undefined'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react"
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "node_modules/next/types/global.d.ts"
   ]
 }


### PR DESCRIPTION
This PR allowing tree-shaking to work on client / server bundles using [`process.browser`](https://github.com/vercel/next.js/blob/58ea3bb47966ba7ae0f12a9267b54f79a5b4c9fc/test/unit/next-babel-loader.unit.test.js#L124) which is an env variable that gets replaced by next build.

Before, (client bundle)
![image](https://user-images.githubusercontent.com/9304194/106276803-c3f56380-6240-11eb-93cf-5fb52c27eb82.png)


After, (client bundle)
![next-i18next-after-fix](https://user-images.githubusercontent.com/9304194/106276525-5e08dc00-6240-11eb-81c6-5d91d865f0ac.png)

In the `after` image you can see that `createConfig` function is much smaller & optimized.
