### PR TITLE
fix: added Trans to TS definition v8-beta

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -4,6 +4,7 @@ import * as React from 'react'
 import {
   I18nContext,
   useTranslation,
+  Trans,
   TransProps,
   withTranslation,
   WithTranslation as ReactI18nextWithTranslation
@@ -62,5 +63,6 @@ export {
   I18nContext,
   appWithTranslation,
   useTranslation,
+  Trans,
   withTranslation,
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -5,7 +5,6 @@ import {
   I18nContext,
   useTranslation,
   Trans,
-  TransProps,
   withTranslation,
   WithTranslation as ReactI18nextWithTranslation
 } from 'react-i18next'
@@ -38,7 +37,6 @@ export type NextI18NextInternals = {
   i18n: I18n;
 }
 
-export type Trans = (props: TransProps) => any
 export type UseTranslation = typeof useTranslation
 export type AppWithTranslation = typeof appWithTranslation
 export type TFunction = I18NextTFunction


### PR DESCRIPTION
Currently, the ts definition lacked the `Trans` component. I added the import from `react-i18next`.