### PR TITLE
feat: added customClientLocalePath property

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ const { i18n: { language } } = useContext(I18nContext)
 | `otherLanguages` (required) | `[]`  |
 | `localeExtension` | `'json'`  |
 | `localePath` (required) | `'/public/static/locales'`  |
+| `customClientLocalePath` | `'/someOtherFolder/locales'`  |
 | `localeStructure` | `'{{lng}}/{{ns}}'`  |
 | `localeSubpaths` | `{}`  |
 | `serverLanguageDetection` | `true`  |

--- a/src/config/create-config.ts
+++ b/src/config/create-config.ts
@@ -36,9 +36,10 @@ export const createConfig = (userConfig) => {
     localeExtension,
     localePath,
     localeStructure,
+    customClientLocalePath,
   } = combinedConfig
 
-  /** 
+  /**
    * Skips translation file resolution while in cimode
    * https://github.com/isaachinman/next-i18next/pull/851#discussion_r503113620
   */
@@ -57,7 +58,7 @@ export const createConfig = (userConfig) => {
       const fs = eval("require('fs')")
       const path = require('path')
       let serverLocalePath = localePath
-  
+
       /*
         Validate defaultNS
         https://github.com/isaachinman/next-i18next/issues/358
@@ -67,14 +68,14 @@ export const createConfig = (userConfig) => {
         const defaultNSPath = path.join(localePath, defaultFile)
         const defaultNSExists = fs.existsSync(defaultNSPath)
         if (!defaultNSExists) {
-  
+
           /*
             If defaultNS doesn't exist, try to fall back to the deprecated static folder
             https://github.com/isaachinman/next-i18next/issues/523
           */
           const staticDirPath = path.resolve(process.cwd(), STATIC_LOCALE_PATH, defaultFile)
           const staticDirExists = fs.existsSync(staticDirPath)
-  
+
           if (staticDirExists) {
             consoleMessage('warn', 'next-i18next: Falling back to /static folder, deprecated in next@9.1.*', combinedConfig)
             serverLocalePath = STATIC_LOCALE_PATH
@@ -83,7 +84,7 @@ export const createConfig = (userConfig) => {
           }
         }
       }
-  
+
       /*
         Set server side backend
       */
@@ -91,7 +92,7 @@ export const createConfig = (userConfig) => {
         loadPath: path.resolve(process.cwd(), `${serverLocalePath}/${localeStructure}.${localeExtension}`),
         addPath: path.resolve(process.cwd(), `${serverLocalePath}/${localeStructure}.missing.${localeExtension}`),
       }
-  
+
       /*
         Set server side preload (namespaces)
       */
@@ -102,8 +103,8 @@ export const createConfig = (userConfig) => {
     }
   } else {
 
-    let clientLocalePath = localePath
-    
+    let clientLocalePath = customClientLocalePath || localePath
+
     /*
       Remove public prefix from client site config
     */

--- a/src/config/default-config.ts
+++ b/src/config/default-config.ts
@@ -15,6 +15,7 @@ export const defaultConfig = {
   localeStructure: LOCALE_STRUCTURE,
   localeExtension: LOCALE_EXTENSION,
   localeSubpaths: {},
+  customClientLocalePath: null,
   use: [],
   defaultNS: DEFAULT_NAMESPACE,
   interpolation: {

--- a/types.d.ts
+++ b/types.d.ts
@@ -21,6 +21,7 @@ export type InitConfig = {
   ignoreRoutes?: string[];
   localeExtension?: string;
   localePath?: string;
+  customClientLocalePath?: string;
   localeStructure?: string;
   otherLanguages: string[];
   localeSubpaths?: Record<string, string>;


### PR DESCRIPTION
I'm currently working on a project where we're using next & next-i18next within a nx monorepo. and in this case we needed a custom path property to load the translation files in the client.