### PR TITLE
refactor: Use serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     "i18next": "^19.8.4",
     "i18next-fs-backend": "^1.0.7",
     "i18next-http-backend": "^1.0.21",
-    "react-i18next": "^11.7.3"
+    "react-i18next": "^11.7.3",
+    "serialize-javascript": "^5.0.1"
   },
   "peerDependencies": {
     "next": ">= 9.5.0",

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -24,11 +24,13 @@ export const appWithTranslation = <P extends Record<string, unknown>>(WrappedCom
         userConfig,
       } = props.pageProps._nextI18Next
 
+      const parsedUserConfig = Function(`'use strict';return(${userConfig})`)()
+
       locale = initialLocale;
   
       ({ i18n } = createClient({
         ...createConfig({
-          ...userConfig,
+          ...parsedUserConfig,
           lng: initialLocale,
         }),
         lng: initialLocale,

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import serialize from 'serialize-javascript'
 import path from 'path'
 
 import { createConfig } from './config/createConfig'
@@ -43,7 +44,7 @@ export const serverSideTranslations = async (
     _nextI18Next: {
       initialI18nStore,
       initialLocale,
-      userConfig,
+      userConfig: serialize(userConfig),
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7300,6 +7300,13 @@ serialize-javascript@^4.0.0:
   dependencies:
     randombytes "^2.1.0"
 
+serialize-javascript@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
+  dependencies:
+    randombytes "^2.1.0"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
Uses [serialize-javascript](https://www.npmjs.com/package/serialize-javascript) to stringify a user's i18next config, which may contain primitives (like functions) that NextJs will refuse to serialise out of the box.

The config gets serialised in `serverSideTranslations`, and then reparsed in `appWithTranslation` via `Function()`.

This allows us to maintain a `next-i18next.config.js` file, without requiring the user to import it themselves, or pass it as arguments into any of `next-i18next`'s functions.

Fixes #931.