### PR TITLE
fix: Add check for type of window

### DIFF
--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import fs from 'fs'
 import path from 'path'
 

--- a/src/config/createConfig.ts
+++ b/src/config/createConfig.ts
@@ -41,7 +41,7 @@ export const createConfig = (userConfig: UserConfig): InternalConfig => {
     combinedConfig.fallbackLng = combinedConfig.defaultLocale
   }
 
-  if (!process.browser) {
+  if (!process.browser && typeof window === 'undefined') {
     combinedConfig.preload = locales
 
     const hasCustomBackend = userConfig?.use?.some((b) => b.type === 'backend')

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -13,7 +13,7 @@ export const defaultConfig = {
     locales: LOCALES,
   },
   get initImmediate(): boolean {
-    return process.browser
+    return process.browser && typeof window !== 'undefined'
   },
   interpolation: {
     escapeValue: false,


### PR DESCRIPTION
This is needed when working in env that is outside of Next.js (like storybook)