### PR TITLE
fix: prevent loading translations on each request

### DIFF
--- a/examples/simple/next-i18next.config.js
+++ b/examples/simple/next-i18next.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  debug: true,
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'de'],

--- a/examples/simple/next-i18next.config.js
+++ b/examples/simple/next-i18next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  debug: true,
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'de'],

--- a/src/createClient/node.test.ts
+++ b/src/createClient/node.test.ts
@@ -7,9 +7,9 @@ const config = {
   use: [],
 } as InternalConfig
 
-describe('createClientBrowser', () => {
+describe('createClientNode', () => {
+  const client = createClientNode(config)
   it('returns a node client', () => {
-    const client = createClientNode(config)
     expect(typeof client.initPromise.then).toEqual('function')
     expect(typeof client.i18n.addResource).toEqual('function')
     expect(typeof (client.i18n as any).translator).toEqual('object')
@@ -17,5 +17,22 @@ describe('createClientBrowser', () => {
       (client.i18n.options as any).defaultLocale
     ).toEqual(config.defaultLocale)
     expect((client.i18n.options as any).locales).toEqual(config.locales)
+    expect((client.i18n.options as any).isClone).not.toEqual(true)
+  })
+
+  describe('createClientNode a second time should return a clone of i18next', () => {
+    it('returns a node client', () => {
+      const secondClient = createClientNode(config)
+      expect(typeof secondClient.initPromise.then).toEqual('function')
+      expect(typeof secondClient.i18n.addResource).toEqual('function')
+      expect(typeof (secondClient.i18n as any).translator).toEqual('object')
+      expect(
+        (secondClient.i18n.options as any).defaultLocale
+      ).toEqual(config.defaultLocale)
+      expect((secondClient.i18n.options as any).locales).toEqual(config.locales)
+      expect((secondClient.i18n.options as any).isClone).toEqual(true)
+      expect(secondClient).not.toEqual(client)
+      expect((secondClient as any).store).toEqual((client as any).store)
+    })
   })
 })

--- a/src/createClient/node.test.ts
+++ b/src/createClient/node.test.ts
@@ -7,8 +7,8 @@ const config = {
 } as any
 
 describe('createClientNode', () => {
-  const client = createClientNode(config)
   it('returns a node client', () => {
+    const client = createClientNode(config)
     expect(typeof client.initPromise.then).toEqual('function')
     expect(typeof client.i18n.addResource).toEqual('function')
     expect(typeof (client.i18n as any).translator).toEqual('object')
@@ -16,22 +16,5 @@ describe('createClientNode', () => {
       (client.i18n.options as any).defaultLocale
     ).toEqual(config.defaultLocale)
     expect((client.i18n.options as any).locales).toEqual(config.locales)
-    expect((client.i18n.options as any).isClone).not.toEqual(true)
-  })
-
-  describe('createClientNode a second time should return a clone of i18next', () => {
-    it('returns a node client', () => {
-      const secondClient = createClientNode(config)
-      expect(typeof secondClient.initPromise.then).toEqual('function')
-      expect(typeof secondClient.i18n.addResource).toEqual('function')
-      expect(typeof (secondClient.i18n as any).translator).toEqual('object')
-      expect(
-        (secondClient.i18n.options as any).defaultLocale
-      ).toEqual(config.defaultLocale)
-      expect((secondClient.i18n.options as any).locales).toEqual(config.locales)
-      expect((secondClient.i18n.options as any).isClone).toEqual(true)
-      expect(secondClient).not.toEqual(client)
-      expect((secondClient as any).store).toEqual((client as any).store)
-    })
   })
 })

--- a/src/createClient/node.ts
+++ b/src/createClient/node.ts
@@ -6,7 +6,9 @@ import { InternalConfig, CreateClientReturn, InitPromise, I18n } from '../types'
 let instance: I18n
 
 export default (config: InternalConfig): CreateClientReturn => {
-  if (!instance) instance = i18n.createInstance(config)
+  if (!instance) {
+    instance = i18n.createInstance(config)
+  }
   let initPromise: InitPromise
 
   if (!instance.isInitialized) {

--- a/src/createClient/node.ts
+++ b/src/createClient/node.ts
@@ -1,29 +1,14 @@
 import i18n from 'i18next'
 import i18nextFSBackend from 'i18next-fs-backend'
 
-import { InternalConfig, CreateClientReturn, InitPromise } from '../types'
+import { InternalConfig, CreateClientReturn, InitPromise, I18n } from '../types'
 
-let instance
+let instance: I18n
 
 export default (config: InternalConfig): CreateClientReturn => {
+  if (!instance) instance = i18n.createInstance(config)
   let initPromise: InitPromise
-  if (instance) {
-    // using cloneInstance for subsequent calls,
-    // prevents to load the translations again via backend plugin,
-    // like in i18next-http-middleware
-    let i18nextClone
-    initPromise = new Promise((resolve, reject) => {
-      i18nextClone = instance.cloneInstance({
-        ...config,
-        initImmediate: false,
-      }, (err, t) => err ? reject(err) : resolve(t))
-    })
-    return {
-      i18n: i18nextClone,
-      initPromise,
-    }
-  }
-  instance = i18n.createInstance(config)
+
   if (!instance.isInitialized) {
     const hasCustomBackend = config?.use?.some((b) => b.type === 'backend')
     if (!hasCustomBackend) {


### PR DESCRIPTION
With the current implementation i18next is initialized on each request on server side.
This triggers a backend load each time.
When using "external" backend plugins via `.use()` this will generate unnecessary load and traffic, i.e. when using i18next-http-backend or i18next-locize-backend.

This PR tries to imitate the "old" behaviour done by i18next-http-middleware, like here: https://github.com/i18next/i18next-http-middleware/blob/master/lib/index.js#L39
where the i18next instance was cloned on each request, this way no unnecessary backend fetch was done.