### PR TITLE
fix: generate types using tsc and stop shipping the /src directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 # Untranspiled source and examples
 examples
+src
 
 # Dependencies
 node_modules

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "dist/commonjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "./types.d.ts",
+  "types": "dist/types/types.d.ts",
   "license": "MIT",
   "engines": {
     "node": ">=10"
@@ -32,7 +32,8 @@
     "build:es": "BABEL_ENV=es babel src --extensions '.ts,.tsx' --out-dir dist/es --copy-files",
     "build:cjs": "BABEL_ENV=cjs babel src --extensions '.ts,.tsx' --out-dir dist/commonjs --copy-files",
     "build:esm": "BABEL_ENV=esm babel src --extensions '.ts,.tsx' --out-dir dist/esm --copy-files",
-    "build": "yarn clean && yarn build:cjs && yarn build:es && yarn build:esm",
+    "build:types": "tsc --noEmit false --declaration --emitDeclarationOnly --outDir dist/types",
+    "build": "yarn clean && yarn build:cjs && yarn build:es && yarn build:esm && yarn build:types",
     "build:examples/simple": "yarn --cwd examples/simple && yarn --cwd examples/simple build",
     "prepublishOnly": "yarn build",
     "run-example": "yarn build && cd examples/simple && yarn && yarn dev",

--- a/serverSideTranslations.d.ts
+++ b/serverSideTranslations.d.ts
@@ -1,1 +1,1 @@
-export { serverSideTranslations } from './src/serverSideTranslations'
+export { serverSideTranslations } from './dist/types/serverSideTranslations'

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -6,7 +6,7 @@ import type { AppProps as NextJsAppProps } from 'next/app'
 import { createConfig } from './config/createConfig'
 import createClient from './createClient'
 
-import { SSRConfig, UserConfig } from '../types'
+import { SSRConfig, UserConfig } from './types'
 
 export { I18nContext, Trans, useTranslation, withTranslation } from 'react-i18next'
 

--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import { createConfig } from './createConfig'
-import { UserConfig } from '../../types'
+import { UserConfig } from '../types'
 
 jest.mock('fs', () => ({
   existsSync: jest.fn(),

--- a/src/config/createConfig.ts
+++ b/src/config/createConfig.ts
@@ -1,5 +1,5 @@
 import { defaultConfig } from './defaultConfig'
-import { InternalConfig, UserConfig } from '../../types'
+import { InternalConfig, UserConfig } from '../types'
 
 const deepMergeObjects = ['backend', 'detection'] as (keyof Pick<UserConfig, 'backend' | 'detection'>)[]
 

--- a/src/createClient/browser.ts
+++ b/src/createClient/browser.ts
@@ -1,6 +1,6 @@
 import i18n from 'i18next'
 
-import { InternalConfig, CreateClientReturn, InitPromise } from '../../types'
+import { InternalConfig, CreateClientReturn, InitPromise } from '../types'
 
 export default (config: InternalConfig): CreateClientReturn => {
   const instance = i18n.createInstance(config)

--- a/src/createClient/node.ts
+++ b/src/createClient/node.ts
@@ -1,7 +1,7 @@
 import i18n from 'i18next'
 import i18nextFSBackend from 'i18next-fs-backend'
 
-import { InternalConfig, CreateClientReturn, InitPromise } from '../../types'
+import { InternalConfig, CreateClientReturn, InitPromise } from '../types'
 
 export default (config: InternalConfig): CreateClientReturn => {
   const instance = i18n.createInstance(config)

--- a/src/serverSideTranslations.test.ts
+++ b/src/serverSideTranslations.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { UserConfig } from '../types'
+import { UserConfig } from './types'
 import { serverSideTranslations } from './serverSideTranslations'
 
 jest.mock('fs', () => ({

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import { createConfig } from './config/createConfig'
 import createClient from './createClient'
 
-import { UserConfig, SSRConfig } from '../types'
+import { UserConfig, SSRConfig } from './types'
 
 const DEFAULT_CONFIG_PATH = './next-i18next.config.js'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import {
   WithTranslation as ReactI18nextWithTranslation,
 } from 'react-i18next'
 import { InitOptions, i18n, TFunction as I18NextTFunction } from 'i18next'
-import { appWithTranslation } from './src'
+import { appWithTranslation } from './'
 
 type NextJsI18NConfig = {
   defaultLocale: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import {
   withTranslation,
   WithTranslation as ReactI18nextWithTranslation,
 } from 'react-i18next'
-import { InitOptions, i18n, TFunction as I18NextTFunction } from 'i18next'
+import { InitOptions, TFunction as I18NextTFunction } from 'i18next'
 import { appWithTranslation, i18n } from './'
 
 type NextJsI18NConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import {
   withTranslation,
   WithTranslation as ReactI18nextWithTranslation,
 } from 'react-i18next'
-import { InitOptions, TFunction as I18NextTFunction } from 'i18next'
+import { InitOptions, i18n as I18NextClient, TFunction as I18NextTFunction } from 'i18next'
 import { appWithTranslation, i18n } from './'
 
 type NextJsI18NConfig = {
@@ -37,7 +37,7 @@ export type InternalConfig = Omit<UserConfig, 'i18n'> & NextJsI18NConfig & {
 export type UseTranslation = typeof useTranslation
 export type AppWithTranslation = typeof appWithTranslation
 export type TFunction = I18NextTFunction
-export type I18n = i18n
+export type I18n = I18NextClient
 export type WithTranslationHocType = typeof withTranslation
 export type WithTranslation = ReactI18nextWithTranslation
 export type InitPromise = Promise<TFunction>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,13 +1783,13 @@
     eslint-utils "^2.0.0"
 
 "@typescript-eslint/parser@^4.11.1":
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.11.1.tgz#981e18de2e019d6ca312596615f92e8f6f6598ed"
-  integrity sha512-BJ3jwPQu1jeynJ5BrjLuGfK/UJu6uwHxJ/di7sanqmUmxzmyIcd3vz58PMR7wpi8k3iWq2Q11KMYgZbUpRoIPw==
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.16.1.tgz#3bbd3234dd3c5b882b2bcd9899bc30e1e1586d2a"
+  integrity sha512-/c0LEZcDL5y8RyI1zLcmZMvJrsR6SM1uetskFkoh3dvqDKVXPsXI+wFB/CbVw7WkEyyTKobC1mUNp/5y6gRvXg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.11.1"
-    "@typescript-eslint/types" "4.11.1"
-    "@typescript-eslint/typescript-estree" "4.11.1"
+    "@typescript-eslint/scope-manager" "4.16.1"
+    "@typescript-eslint/types" "4.16.1"
+    "@typescript-eslint/typescript-estree" "4.16.1"
     debug "^4.1.1"
 
 "@typescript-eslint/scope-manager@4.11.1":
@@ -1808,6 +1808,14 @@
     "@typescript-eslint/types" "4.15.1"
     "@typescript-eslint/visitor-keys" "4.15.1"
 
+"@typescript-eslint/scope-manager@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.16.1.tgz#244e2006bc60cfe46987e9987f4ff49c9e3f00d5"
+  integrity sha512-6IlZv9JaurqV0jkEg923cV49aAn8V6+1H1DRfhRcvZUrptQ+UtSKHb5kwTayzOYTJJ/RsYZdcvhOEKiBLyc0Cw==
+  dependencies:
+    "@typescript-eslint/types" "4.16.1"
+    "@typescript-eslint/visitor-keys" "4.16.1"
+
 "@typescript-eslint/types@4.11.1":
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.11.1.tgz#3ba30c965963ef9f8ced5a29938dd0c465bd3e05"
@@ -1817,6 +1825,11 @@
   version "4.15.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.1.tgz#da702f544ef1afae4bc98da699eaecd49cf31c8c"
   integrity sha512-iGsaUyWFyLz0mHfXhX4zO6P7O3sExQpBJ2dgXB0G5g/8PRVfBBsmQIc3r83ranEQTALLR3Vko/fnCIVqmH+mPw==
+
+"@typescript-eslint/types@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.16.1.tgz#5ba2d3e38b1a67420d2487519e193163054d9c15"
+  integrity sha512-nnKqBwMgRlhzmJQF8tnFDZWfunXmJyuXj55xc8Kbfup4PbkzdoDXZvzN8//EiKR27J6vUSU8j4t37yUuYPiLqA==
 
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
@@ -1858,6 +1871,19 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.16.1.tgz#c2fc46b05a48fbf8bbe8b66a63f0a9ba04b356f1"
+  integrity sha512-m8I/DKHa8YbeHt31T+UGd/l8Kwr0XCTCZL3H4HMvvLCT7HU9V7yYdinTOv1gf/zfqNeDcCgaFH2BMsS8x6NvJg==
+  dependencies:
+    "@typescript-eslint/types" "4.16.1"
+    "@typescript-eslint/visitor-keys" "4.16.1"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/visitor-keys@4.11.1":
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.1.tgz#4c050a4c1f7239786e2dd4e69691436143024e05"
@@ -1872,6 +1898,14 @@
   integrity sha512-tYzaTP9plooRJY8eNlpAewTOqtWW/4ff/5wBjNVaJ0S0wC4Gpq/zDVRTJa5bq2v1pCNQ08xxMCndcvR+h7lMww==
   dependencies:
     "@typescript-eslint/types" "4.15.1"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.16.1.tgz#d7571fb580749fae621520deeb134370bbfc7293"
+  integrity sha512-s/aIP1XcMkEqCNcPQtl60ogUYjSM8FU2mq1O7y5cFf3Xcob1z1iXWNB6cC43Op+NGRTFgGolri6s8z/efA9i1w==
+  dependencies:
+    "@typescript-eslint/types" "4.16.1"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":
@@ -3705,17 +3739,17 @@ dayjs@^1.9.3:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"
   integrity sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==
 
-debug@4, debug@4.3.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@4.3.2:
+debug@4, debug@4.3.2, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,9 +54,9 @@
     cross-fetch "3.0.6"
 
 "@babel/cli@^7.10.4":
-  version "7.12.8"
-  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.12.8.tgz#3b24ed2fd5da353ee6f19e8935ff8c93b5fe8430"
-  integrity sha512-/6nQj11oaGhLmZiuRUfxsujiPDc9BBReemiXgIbxc+M5W+MIiFKYwvNDJvBfnGKNsJTKbUfEheKc9cwoPHAVQA==
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.13.0.tgz#48e77614e897615ca299bece587b68a70723ff4c"
+  integrity sha512-y5AohgeVhU+wO5kU1WGMLdocFj83xCxVjsVFa2ilII8NEwmBZvx7Ambq621FbFIK68loYJ9p43nfoi6es+rzSA==
   dependencies:
     commander "^4.0.1"
     convert-source-map "^1.1.0"


### PR DESCRIPTION
By using typescripts declaration mode we can generate d.ts files for all of the relevant types and stop shipping the /src directory

fix for https://github.com/isaachinman/next-i18next/issues/1026