### PR TITLE
fix: better support for shallow route changes

### DIFF
--- a/src/appWithTranslation.server.test.tsx
+++ b/src/appWithTranslation.server.test.tsx
@@ -40,6 +40,10 @@ const props = {
       },
     },
   } as any,
+  router: {
+    locale: 'en',
+    route: '/',
+  },
 } as any
 
 const renderComponent = () =>

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -46,7 +46,8 @@ export const appWithTranslation = (
         throw new Error('appWithTranslation was called without config.i18n')
       }
 
-      return createClient({
+
+      const instance = createClient({
         ...createConfig({
           ...userConfig,
           lng: locale,
@@ -54,11 +55,11 @@ export const appWithTranslation = (
         lng: locale,
         resources: initialI18nStore,
       }).i18n
-    }, [_nextI18Next, locale])
 
-    useMemo(() => {
-      globalI18n = i18n
-    }, [i18n])
+      globalI18n = instance
+
+      return instance
+    }, [_nextI18Next, locale])
 
     return i18n !== null ? (
       <I18nextProvider

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -22,12 +22,17 @@ export const appWithTranslation = (
   configOverride: UserConfig | null = null,
 ) => {
   const AppWithTranslation = (props: AppProps) => {
-    let i18n: I18NextClient | null = null
-    let locale = null
+    const { _nextI18Next } = props.pageProps
+    const { locale } = props.router
 
-    if (props?.pageProps?._nextI18Next) {
-      let { userConfig } = props.pageProps._nextI18Next
-      const { initialI18nStore, initialLocale } = props.pageProps._nextI18Next
+    // Memoize the instance and only re-initialize when either:
+    // 1. The route changes (non-shallowly)
+    // 2. Router locale changes
+    const i18n: I18NextClient | null = useMemo(() => {
+      if (!locale || !_nextI18Next) return null
+
+      let { userConfig } = _nextI18Next
+      const { initialI18nStore } = _nextI18Next
 
       if (userConfig === null && configOverride === null) {
         throw new Error('appWithTranslation was called without a next-i18next config')
@@ -41,17 +46,15 @@ export const appWithTranslation = (
         throw new Error('appWithTranslation was called without config.i18n')
       }
 
-      locale = initialLocale;
-
-      ({ i18n } = createClient({
+      return createClient({
         ...createConfig({
           ...userConfig,
-          lng: initialLocale,
+          lng: locale,
         }),
-        lng: initialLocale,
+        lng: locale,
         resources: initialI18nStore,
-      }))
-    }
+      }).i18n
+    }, [_nextI18Next, locale])
 
     useMemo(() => {
       globalI18n = i18n

--- a/src/serverSideTranslations.test.tsx
+++ b/src/serverSideTranslations.test.tsx
@@ -18,7 +18,6 @@ const DummyApp = appWithTranslation(() => (
 const props = {
   pageProps: {
     _nextI18Next: {
-      initialLocale: 'en',
       userConfig: {
         i18n: {
           defaultLocale: 'en',
@@ -185,7 +184,6 @@ describe('serverSideTranslations', () => {
         initialI18nStore: {
           'en-US': {},
         },
-        initialLocale: 'en-US',
         userConfig: {
           i18n: {
             defaultLocale: 'en-US',

--- a/src/serverSideTranslations.test.tsx
+++ b/src/serverSideTranslations.test.tsx
@@ -27,6 +27,9 @@ const props = {
       },
     },
   } as any,
+  router: {
+    locale: 'en',
+  },
 } as any
 
 const renderDummyComponent = () =>

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -106,7 +106,6 @@ export const serverSideTranslations = async (
   return {
     _nextI18Next: {
       initialI18nStore,
-      initialLocale,
       userConfig: config.serializeConfig ? userConfig : null,
     },
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,6 @@ export type CreateClientReturn = {
 export type SSRConfig = {
   _nextI18Next: {
     initialI18nStore: any
-    initialLocale: string
     userConfig: UserConfig | null
   }
 }


### PR DESCRIPTION
* Memoize the i18n client and do not re-create it unless the route or
  locale has changed (fix #1059).

* Let Next's router locale take precedence over initialLocale.