### PR TITLE
fix: i18next clone resources only, fixes memory leak

### DIFF
--- a/src/createClient/node.test.ts
+++ b/src/createClient/node.test.ts
@@ -19,7 +19,7 @@ describe('createClientNode', () => {
     expect((client.i18n.options as any).isClone).not.toEqual(true)
   })
 
-  describe('createClientNode a second time should return a clone of i18next', () => {
+  describe('createClientNode a second time should return the same of i18next store', () => {
     it('returns a node client', () => {
       const secondClient = createClientNode(config)
       expect(typeof secondClient.initPromise.then).toEqual('function')
@@ -29,7 +29,6 @@ describe('createClientNode', () => {
         (secondClient.i18n.options as any).defaultLocale
       ).toEqual(config.defaultLocale)
       expect((secondClient.i18n.options as any).locales).toEqual(config.locales)
-      expect((secondClient.i18n.options as any).isClone).toEqual(true)
       expect(secondClient).not.toEqual(client)
       expect((secondClient as any).store).toEqual((client as any).store)
     })

--- a/src/createClient/node.test.ts
+++ b/src/createClient/node.test.ts
@@ -19,7 +19,7 @@ describe('createClientNode', () => {
     expect((client.i18n.options as any).isClone).not.toEqual(true)
   })
 
-  describe('createClientNode a second time should return the same of i18next store', () => {
+  describe('createClientNode a second time should return the same i18next store', () => {
     it('returns a node client', () => {
       const secondClient = createClientNode(config)
       expect(typeof secondClient.initPromise.then).toEqual('function')

--- a/src/createClient/node.ts
+++ b/src/createClient/node.ts
@@ -6,14 +6,12 @@ import { InternalConfig, CreateClientReturn, InitPromise, I18n } from '../types'
 let instance: I18n
 
 export default (config: InternalConfig): CreateClientReturn => {
-  if (!instance) {
-    instance = i18n.createInstance(config)
-  } else {
-    instance = instance.cloneInstance({
-      ...config,
-      initImmediate: false,
-    })
-  }
+  const i18nStore = instance && instance.store
+  instance = i18n.createInstance({
+    ...config,
+    resources: i18nStore ? i18nStore.data as any : undefined,
+  })
+
   let initPromise: InitPromise
 
   if (!instance.isInitialized) {


### PR DESCRIPTION
- ensures a new i18next instance is created on each request, to ensure concurrent requests are isolated
- does only "clone" the loaded i18next resources, not a complete i18next clone (might be this slim clone functionality, will become a real i18next core functionality)

fixes #1101