### PR TITLE
feat: adjust translations path so that it can point to a specific path rath…

### DIFF
--- a/src/serverSideTranslations.test.ts
+++ b/src/serverSideTranslations.test.ts
@@ -20,7 +20,22 @@ describe('serverSideTranslations', () => {
       .rejects
       .toThrow('Initial locale argument was not passed into serverSideTranslations')
   })
-
+  it('finds namespaces when monoreporoot is defined', async () => {
+    (fs.readdirSync as jest.Mock).mockReturnValue(['one/two/three'])
+    const props = await serverSideTranslations('en-US', undefined,{
+      i18n: {
+        defaultLocale: 'en-US',
+        locales: ['en-US', 'fr-CA'],
+      },
+      translationsRootDir: 'one/two/three',
+    })
+    expect(fs.readdirSync).toHaveBeenCalledTimes(1)
+    expect(fs.readdirSync).toHaveBeenCalledWith(
+      expect.stringMatching(/(.*)(one\/two\/three\/)(public\/locales\/en-US)/)
+    )
+    expect(Object.values(props._nextI18Next.initialI18nStore))
+      .toEqual([{ 'one/two/three': {} }])
+  })
   it('returns all namespaces if namespacesRequired is not provided', async () => {
     (fs.readdirSync as jest.Mock).mockReturnValue(['one', 'two', 'three'])
     const props = await serverSideTranslations('en-US', undefined, {

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -26,9 +26,9 @@ export const serverSideTranslations = async (
   if (userConfig === null) {
     throw new Error('next-i18next was unable to find a user config')
   }
-
+  const { translationsRootDir, ...rest } = userConfig
   const config = createConfig({
-    ...userConfig,
+    ...rest,
     lng: initialLocale,
   })
 
@@ -58,7 +58,7 @@ export const serverSideTranslations = async (
       fs.readdirSync(path)
         .map(file => file.replace(`.${localeExtension}`, ''))
 
-    namespacesRequired = getAllNamespaces(path.resolve(process.cwd(), `${localePath}/${defaultLocale}`))
+    namespacesRequired = getAllNamespaces(path.resolve(process.cwd(), `${translationsRootDir ? path.join(translationsRootDir, '/') : ''}${localePath}/${defaultLocale}`))
   }
 
   namespacesRequired.forEach((ns) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type UserConfig = {
   localeStructure?: string
   serializeConfig?: boolean
   strictMode?: boolean
+  translationsRootDir?: string
   use?: any[]
 } & InitOptions
 


### PR DESCRIPTION
Hi,
  I wanted to start this and get some feedback. We have a scenario where we are using a monorepo tool called `Nx`. This moves the root `next` app into a subdirectory for example `apps/appName`.
  
  In this scenario we technically moved the `next.config.js` into `apps/appName` and this breaks translations because we can't find the `userConfig` without passing file paths to the many calls to `serverSideTranslations` our app makes.

 I added a `translationsRootDir` config option which is removed from the config before passing the config back to `next`. By doing this, one can leave the next config in root so that the config can be found by default, and we can adjust the namespace resolution to follow the `translationsRootDir` when defined.

One drawback I see though is that the entire "mono" would be following this one path, which may not be ideal.

I plan to update docs once this is a bit more ironed out and see if we can come to a solution.

I'm not a `next.js` expert by any means so I may be off in some understanding.

  