### PR TITLE
build: install @babel/runtime to satisfy dependency of @babel/plugin-transform-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
+    "@babel/runtime": "^7.13.17",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/i18next-fs-backend": "^1.0.0",
     "core-js": "^3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,6 +986,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.17":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
+  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"


### PR DESCRIPTION
The `@babel/plugin-transform-runtime` needs the dependency `@babel/runtime` in production, as stated in https://babeljs.io/docs/en/babel-plugin-transform-runtime. Because of that, Yarn v2 PnP complains when next-i18next is used in a NextJS project and gives the following error:

```
Module not found: next-i18next tried to access @babel/runtime, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @babel/runtime (via "@babel\runtime\helpers\defineProperty")
```

The required dependency  `@babel/runtime` was added in package.json to resolve that.

To test the change, I ran the `examples/simple` project after installing, and it worked well.

Closes #1079 