### PR TITLE
fix: i18n.getFixedT to return correct t function

### DIFF
--- a/src/serverSideTranslations.test.ts
+++ b/src/serverSideTranslations.test.ts
@@ -31,8 +31,11 @@ describe('serverSideTranslations', () => {
     } as UserConfig)
     expect(fs.readdirSync).toHaveBeenCalledTimes(1)
     expect(fs.readdirSync).toHaveBeenCalledWith(expect.stringMatching('/public/locales/en-US'))
-    expect(Object.values(props._nextI18Next.initialI18nStore))
-      .toEqual([{ one: {}, three: {}, two: {} }])
+    expect(props._nextI18Next.initialI18nStore)
+      .toEqual({
+        'en-US': { one: {}, three: {}, two: {} },
+        'fr-CA': { one: {}, three: {}, two: {} }}
+      )
   })
 
   it('returns props', async () => {
@@ -47,6 +50,7 @@ describe('serverSideTranslations', () => {
       _nextI18Next: {
         initialI18nStore: {
           'en-US': {},
+          'fr-CA': {},
         },
         initialLocale: 'en-US',
         userConfig: {

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -45,13 +45,11 @@ export const serverSideTranslations = async (
 
   await initPromise
 
-  const initialI18nStore: Record<string, any> = {
-    [initialLocale]: {},
-  }
+  const initialI18nStore: Record<string, any> = {}
 
-  if (typeof config.fallbackLng === 'string') {
-    initialI18nStore[config.fallbackLng] = {}
-  }
+  config.locales.forEach(lng => {
+    initialI18nStore[lng] = {}
+  })
 
   if (namespacesRequired.length === 0) {
     const getAllNamespaces = (path: string) =>


### PR DESCRIPTION
# Issue
`i18n.getFixedT` should return`t` function that defaults to given language, but the returned `t` function always returns the translation of the currently selected locale.

Issue details: https://github.com/isaachinman/next-i18next/issues/1184

# Cause
Only the translation of default/current locale is being passed to the client.

# Solution
Pass translation for all locales to the client, so `i18n.getFixedT` has the translation for the given language.