### PR TITLE
fix: Export Resources and DefaultNamespace from typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ import {
   Trans,
   withTranslation,
   WithTranslation as ReactI18nextWithTranslation,
+  Resources,
+  DefaultNamespace,
 } from 'react-i18next'
 import { InitOptions, i18n as I18NextClient, TFunction as I18NextTFunction } from 'i18next'
 import { appWithTranslation, i18n } from './'
@@ -61,4 +63,6 @@ export {
   useTranslation,
   Trans,
   withTranslation,
+  Resources,
+  DefaultNamespace,
 }


### PR DESCRIPTION
# Description

Export the `Resources` and `DefaultNamespace` types from `react-i18next` to allow for proper typing of the `useTranslation` and `serverSideTranslations` functions as described on [react-i18next documentation](https://react.i18next.com/latest/typescript) 

I've added documentation, but I'm not sure that is the better place for it. 