### PR TITLE
fix: resource and default namespace typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,13 +174,8 @@ declare module 'next-i18next' {
     ns2: typeof ns2
   }
 
-  // The default for `next-i18next` is 'common', 
-  // If you use a custom value in `defaultNS` put it here
-  type DefaultNamespace = 'common'
-
   interface Resources extends DefaultResources {}
 }
-
 ```
 
 ### 5. Advanced configuration

--- a/README.md
+++ b/README.md
@@ -158,6 +158,31 @@ To do that, you can pass an array of required namespaces for each page into `ser
 
 Note: `useTranslation` provides namespaces to the component that you use it in. However, `serverSideTranslations` provides the total available namespaces to the entire React tree and belongs on the page level. Both are required.
 
+#### Strict Typings
+
+In order to have strict typings and editor auto-complete, you can extends the type definitions exported by `next-i18next` in a similar way to [react-i18next](https://react.i18next.com/latest/typescript).
+
+This will also provide the correct typings to the `serverSideTranslations` function. 
+
+```ts
+import ns1 from './public/locales/en/ns1.json'
+import ns2 from './public/locales/en/ns2.json'
+
+declare module 'next-i18next' {
+  type DefaultResources = {
+    ns1: typeof ns1
+    ns2: typeof ns2
+  }
+
+  // The default for `next-i18next` is 'common', 
+  // If you use a custom value in `defaultNS` put it here
+  type DefaultNamespace = 'common'
+
+  interface Resources extends DefaultResources {}
+}
+
+```
+
 ### 5. Advanced configuration
 
 

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -6,6 +6,7 @@ import createClient from './createClient'
 
 import { UserConfig, SSRConfig } from './types'
 import { FallbackLng } from 'i18next'
+import { Namespace } from 'react-i18next'
 
 const DEFAULT_CONFIG_PATH = './next-i18next.config.js'
 
@@ -32,9 +33,11 @@ const flatNamespaces = (namespacesByLocale: string[][]) => {
   return Array.from(new Set(allNamespaces))
 }
 
+type NextNamespace<T extends Namespace> = T extends (infer R)[] ? R[] : T[];
+
 export const serverSideTranslations = async (
   initialLocale: string,
-  namespacesRequired: string[] = [],
+  namespacesRequired: NextNamespace<Namespace> = [],
   configOverride: UserConfig | null = null,
 ): Promise<SSRConfig> => {
   if (typeof initialLocale !== 'string') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ import {
   Trans,
   withTranslation,
   WithTranslation as ReactI18nextWithTranslation,
+  Resources,
+  DefaultNamespace,
 } from 'react-i18next'
 import { InitOptions, i18n as I18NextClient, TFunction as I18NextTFunction } from 'i18next'
 import { appWithTranslation, i18n } from './'
@@ -61,4 +63,6 @@ export {
   useTranslation,
   Trans,
   withTranslation,
+  Resources,
+  DefaultNamespace,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,6 @@ import {
   withTranslation,
   WithTranslation as ReactI18nextWithTranslation,
   Resources,
-  DefaultNamespace,
 } from 'react-i18next'
 import { InitOptions, i18n as I18NextClient, TFunction as I18NextTFunction } from 'i18next'
 import { appWithTranslation, i18n } from './'
@@ -64,5 +63,4 @@ export {
   Trans,
   withTranslation,
   Resources,
-  DefaultNamespace,
 }


### PR DESCRIPTION
# Description

Export the `Resources` and `DefaultNamespace` types from `react-i18next` to allow for proper typing of the `useTranslation` and `serverSideTranslations` functions as described on [react-i18next documentation](https://react.i18next.com/latest/typescript) 

I've added documentation, but I'm not sure that is the better place for it. 