### PR TITLE
fix: Respect user-defined prefix/suffix when looking for default NS

### DIFF
--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -116,15 +116,31 @@ describe('createConfig', () => {
       })
     })
 
-    describe('when filesystem is missing defaultNS', () => {
-      it('throws an error', () => {
+    describe('defaultNS validation', () => {
+      it('when filesystem is missing defaultNS throws an error', () => {
         (fs.existsSync as jest.Mock).mockReturnValueOnce(false)
 
         const config = createConfig.bind(null, {
           lng: 'en',
-        } as any)
+        } as UserConfig)
 
         expect(config).toThrow('Default namespace not found at public/locales/en/common.json')
+      })
+
+      it('uses user provided prefix/suffix with localeStructure', () => {
+        (fs.existsSync as jest.Mock).mockReturnValueOnce(false)
+
+        const config = createConfig.bind(null, {
+          interpolation: {
+            prefix: '^^',
+            suffix: '$$',
+          },
+          lng: 'en',
+          localeStructure: '^^lng$$/^^ns$$',
+        } as UserConfig)
+
+        expect(config).toThrow('Default namespace not found at public/locales/en/common.json')
+        expect(fs.existsSync).toHaveBeenCalledWith('public/locales/en/common.json')
       })
     })
 

--- a/src/config/createConfig.ts
+++ b/src/config/createConfig.ts
@@ -56,7 +56,9 @@ export const createConfig = (userConfig: UserConfig): InternalConfig => {
       // https://github.com/isaachinman/next-i18next/issues/358
       //
       if (typeof defaultNS === 'string' && typeof lng !== 'undefined') {
-        const defaultLocaleStructure = localeStructure.replace('{{lng}}', lng).replace('{{ns}}', defaultNS)
+        const prefix = userConfig?.interpolation?.prefix ?? '{{'
+        const suffix = userConfig?.interpolation?.suffix ?? '}}'
+        const defaultLocaleStructure = localeStructure.replace(`${prefix}lng${suffix}`, lng).replace(`${prefix}ns${suffix}`, defaultNS)
         const defaultFile = `/${defaultLocaleStructure}.${localeExtension}`
         const defaultNSPath = path.join(localePath, defaultFile)
         const defaultNSExists = fs.existsSync(defaultNSPath)


### PR DESCRIPTION
Fixes #1090 by respecting any custom `interpolation.prefix` and `interpolation.suffix` while using `localeStructure` to see if the default namespace file exists.

Can be tested by changing `/examples/simple/next-i18next.config.js` to
```
module.exports = {
  i18n: {
    defaultLocale: 'en',
    locales: ['en', 'de'],
  },
  interpolation: {
    prefix: '%{',
    suffix: '}',
  },
  localeStructure: '%{lng}/%{ns}',
}
```

Before the change, this config would result in this error:
```
Error: Default namespace not found at public/locales/%{lng}/%{ns}.json
```

After the change, the error goes away and interpolations work as expected. (To verify that interpolations work, you need to change `/examples/simple/public/locales/en/common.json` to use the `%{` `}` prefix and suffix.)