### PR TITLE
Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ export async function getStaticProps({ locale }) {
 
 Note that `serverSideTranslations` must be imported from `next-i18next/serverSideTranslations` – this is a separate module that contains NodeJs-specific code.
 
-Also, note that `serverSideTranslations` is not compatible with `getInitialProps`, as it _only_ can execute in a server environment, whereas `getInitialProps` is called on the client side when navigating between pages.
+Also, note that `serverSideTranslations` is not compatible with `getInitialProps` and `getServerSideProps`, as it _only_ can execute in a server environment, whereas `getInitialProps` and `getServerSideProps` are called on the client side when navigating between pages.
 
 The `serverSideTranslations` HOC is primarily responsible for passing translations and configuration options into pages, as props.
 


### PR DESCRIPTION
# Issue

We've been getting cases where users are not able to build their Next.js page when using this package (working locally but not on Vercel).

It turns out people are using `getServerSideProps` for their page, which I believe is not supposed to work since the documentation also states `getInitialProps` does not work (both methods are almost identical).

When accessing the `getServerSideProps` page →

<img width="1230" alt="CleanShot 2021-06-10 at 02 50 42@2x" src="https://user-images.githubusercontent.com/28912696/121504238-b55d4c80-c996-11eb-9b70-a5b3e3d96f35.png">
