### PR TITLE
fix: client config ns assignment logic

### DIFF
--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -199,7 +199,12 @@ describe('createConfig', () => {
       expect(config.ns).toEqual(['core'])
     })
 
-    it('returns ns when provided', () => {
+    it('returns ns when provided as a string', () => {
+      const config = createConfig({ lng: 'en', ns: 'core' } as UserConfig)
+      expect(config.ns).toEqual('core')
+    })
+
+    it('returns ns when provided as an array', () => {
       const config = createConfig({ lng: 'en', ns: ['core', 'page'] } as UserConfig)
       expect(config.ns).toEqual(['core', 'page'])
     })

--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -193,5 +193,15 @@ describe('createConfig', () => {
       expect((config.backend as any).hello).toEqual('world')
       expect((config.backend as any).loadPath).toMatch('/locales/{{lng}}/{{ns}}.json')
     })
+
+    it('returns ns as [defaultNS]', () => {
+      const config = createConfig({ defaultNS: 'core', lng: 'en' } as UserConfig)
+      expect(config.ns).toEqual(['core'])
+    })
+
+    it('returns ns when provided', () => {
+      const config = createConfig({ lng: 'en', ns: ['core', 'page'] } as UserConfig)
+      expect(config.ns).toEqual(['core', 'page'])
+    })
   })
 })

--- a/src/config/createConfig.ts
+++ b/src/config/createConfig.ts
@@ -140,7 +140,9 @@ export const createConfig = (userConfig: UserConfig): InternalConfig => {
       loadPath: `${clientLocalePath}/${localeStructure}.${localeExtension}`,
     }
 
-    combinedConfig.ns = [defaultNS]
+    if (!combinedConfig.ns) {
+      combinedConfig.ns = [defaultNS]
+    }
   }
 
   //

--- a/src/config/createConfig.ts
+++ b/src/config/createConfig.ts
@@ -140,7 +140,7 @@ export const createConfig = (userConfig: UserConfig): InternalConfig => {
       loadPath: `${clientLocalePath}/${localeStructure}.${localeExtension}`,
     }
 
-    if (!combinedConfig.ns) {
+    if (typeof combinedConfig.ns !== 'string' && !Array.isArray(combinedConfig.ns)) {
       combinedConfig.ns = [defaultNS]
     }
   }


### PR DESCRIPTION
Resolves #1250 

Since the `ns` option can be either a `string` or `string[]` ([docs ref](https://www.i18next.com/overview/configuration-options)) I am just checking for `combinedConfig.ns` to be defined before assigning `[defaultNs]`.

I've added a couple of tests as requested.