### PR TITLE
fix: set client side backend options only if there is no custom backend

### DIFF
--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -208,5 +208,19 @@ describe('createConfig', () => {
       const config = createConfig({ lng: 'en', ns: ['core', 'page'] } as UserConfig)
       expect(config.ns).toEqual(['core', 'page'])
     })
+
+    describe('hasCustomBackend', () => {
+      it('returns the correct configuration', () => {
+        const config = createConfig({
+          backend: {
+            hello: 'world',
+          },
+          lng: 'en',
+          use: [{
+            type: 'backend',
+          }] } as UserConfig)
+        expect((config.backend as any)).toEqual({ hello: 'world' })
+      })
+    })
   })
 })

--- a/src/config/createConfig.ts
+++ b/src/config/createConfig.ts
@@ -41,10 +41,9 @@ export const createConfig = (userConfig: UserConfig): InternalConfig => {
   if (typeof combinedConfig.fallbackLng === 'undefined') {
     combinedConfig.fallbackLng = combinedConfig.defaultLocale
   }
+  const hasCustomBackend = userConfig?.use?.some((b) => b.type === 'backend')
   if (!process.browser && typeof window === 'undefined') {
     combinedConfig.preload = locales
-
-    const hasCustomBackend = userConfig?.use?.some((b) => b.type === 'backend')
 
     if (!hasCustomBackend) {
       const fs = require('fs')
@@ -133,11 +132,13 @@ export const createConfig = (userConfig: UserConfig): InternalConfig => {
     }
 
     //
-    // Set client side backend
+    // Set client side backend, if there is no custom backend
     //
-    combinedConfig.backend = {
-      addPath: `${clientLocalePath}/${localeStructure}.missing.${localeExtension}`,
-      loadPath: `${clientLocalePath}/${localeStructure}.${localeExtension}`,
+    if (!hasCustomBackend) {
+      combinedConfig.backend = {
+        addPath: `${clientLocalePath}/${localeStructure}.missing.${localeExtension}`,
+        loadPath: `${clientLocalePath}/${localeStructure}.${localeExtension}`,
+      }
     }
 
     if (typeof combinedConfig.ns !== 'string' && !Array.isArray(combinedConfig.ns)) {


### PR DESCRIPTION
Using a different i18next backend having the same backend options like i18next-http-backend is currently causing the custom backend default options to be ignored.

With this fix, the addPath and loadPath options are only configured, if there is no custom backend.