### PR TITLE
fix: improved readme documentation to avoid #462 possibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,13 @@ This tells `next-i18next` what your `defaultLocale` and other locales are, so th
 #### `next-i18next.config.js`
 
 ```js
+const path = require('path')
+
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'de'],
+    defaultLocale: "en",
+    locales: ["en", "fr"],
+    localePath: path.resolve('./public/locales')
   },
 };
 ```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This tells `next-i18next` what your `defaultLocale` and other locales are, so th
 #### `next-i18next.config.js`
 
 ```js
-const path = require('path')
+const path = require('path');
 
 module.exports = {
   i18n: {


### PR DESCRIPTION
Credit goes towards @musps in #462 for the fix. I encountered the same issue after deploying to Vercel and getting a 500 server error loading my ssr pages since my file locale paths couldn't be resolved.

This addition fixes the issue.