### PR TITLE
feat: Support to use `i18next-hmr` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ module.exports = {
 };
 ```
 
+If you want to enable **hot module reload**, use `withHmrNextConfig` plugin at `next.config.js`.
+
+```js
+const withPlugins = require('next-compose-plugins');
+const { withHmrNextConfig } = require('next-i18next/withHmrNextConfig');
+
+const { i18n } = require('./next-i18next.config');
+
+module.exports = withPlugins([
+  withHmrNextConfig(i18n)
+], {
+  // ...
+})
+```
+
 There are three functions that `next-i18next` exports, which you will need to use to translate your project:
 
 #### appWithTranslation

--- a/examples/simple/next.config.js
+++ b/examples/simple/next.config.js
@@ -1,5 +1,4 @@
+const { withHmrNextConfig } = require('next-i18next/withHmrNextConfig')
 const { i18n } = require('./next-i18next.config')
 
-module.exports = {
-  i18n,
-}
+module.exports = withHmrNextConfig(i18n)()

--- a/package.json
+++ b/package.json
@@ -109,6 +109,8 @@
     "hoist-non-react-statics": "^3.2.0",
     "i18next": "^20.1.0",
     "i18next-fs-backend": "^1.0.7",
+    "i18next-hmr": "^1.7.5",
+    "i18next-http-backend": "^1.3.0",
     "react-i18next": "^11.8.13"
   },
   "peerDependencies": {

--- a/src/appWithTranslation.client.test.tsx
+++ b/src/appWithTranslation.client.test.tsx
@@ -26,6 +26,11 @@ jest.mock('i18next-hmr/client', () => ({
   applyClientHMR: jest.fn(),
 }))
 
+jest.mock('i18next-http-backend', () => ({
+  __esmodule: false,
+  default: jest.requireActual('i18next-http-backend'),
+}))
+
 
 const DummyApp = appWithTranslation(() => (
   <div>Hello world</div>

--- a/src/withHmrNextConfig.ts
+++ b/src/withHmrNextConfig.ts
@@ -1,0 +1,99 @@
+import path from 'path'
+import fs from 'fs'
+import type { FallbackLng } from 'i18next'
+import { I18NextHMRPlugin } from 'i18next-hmr/plugin'
+import { NextConfig } from 'next/dist/next-server/server/config-shared'
+
+import { defaultConfig } from './config/defaultConfig'
+import { UserConfig } from './types'
+
+const unique = (list: string[]) => Array.from(new Set<string>(list))
+
+const getLocaleNamespaces = (path: string, localeExtension: string) =>
+  fs.readdirSync(path).map(
+    (file: string) => file.replace(`.${localeExtension}`, '')
+  )
+
+const getNamespaces = ({
+  locales,
+  localeExtension,
+  serverLocalePath,
+}: {
+  localeExtension: string
+  locales: string[]
+  serverLocalePath: string
+}): string[] => {
+  const namespacesByLocale = locales
+    .map(locale => getLocaleNamespaces(
+      path.resolve(process.cwd(), `${serverLocalePath}/${locale}`),
+      localeExtension,
+    ))
+
+  const allNamespaces = []
+  for (const localNamespaces of namespacesByLocale) {
+    allNamespaces.push(...localNamespaces)
+  }
+
+  return unique(allNamespaces)
+}
+
+const getAllLocales = (
+  lng: string,
+  fallbackLng: false | FallbackLng
+): string[] => {
+  if (typeof fallbackLng === 'string') {
+    return unique([lng, fallbackLng])
+  }
+
+  if (Array.isArray(fallbackLng)) {
+    return unique([lng, ...fallbackLng])
+  }
+
+  if (typeof fallbackLng === 'object') {
+    const flattenedFallbacks = Object
+      .values(fallbackLng)
+      .reduce(((all, fallbackLngs) => [ ...all, ...fallbackLngs ]),[])
+    return unique([ lng, ...flattenedFallbacks ])
+  }
+  return [lng]
+}
+
+export const withHmrNextConfig = (i18n: UserConfig & UserConfig['i18n']) => (
+  (nextConfig: NextConfig = {} as NextConfig): NextConfig => {
+    if (process.env.NODE_ENV === 'production') {
+      return Object.assign({}, nextConfig, { i18n })
+    }
+    const localePath = i18n.localePath || defaultConfig.localePath
+    const namespaces = i18n.ns || getNamespaces({
+      localeExtension:
+        i18n.localeExtension || defaultConfig.localeExtension,
+      locales: getAllLocales(
+        i18n.defaultLocale,
+        i18n.fallbackLng || i18n.defaultLocale
+      ),
+      serverLocalePath: localePath,
+    })
+    return Object.assign({}, nextConfig, {
+      i18n,
+      publicRuntimeConfig: {
+        ...nextConfig.publicRuntimeConfig,
+        __HMR_I18N_ENABLED__: true,
+        __HMR_I18N_NAMESPACES__: namespaces,
+      },
+      webpack: (config: any, options: any) => {
+        if (!options.isServer && config.mode === 'development') {
+          const localePath = i18n.localePath || defaultConfig.localePath
+          config.plugins.push(
+            new I18NextHMRPlugin({
+              localesDir: path.resolve(process.cwd(), localePath),
+            })
+          )
+        }
+        if (typeof nextConfig.webpack === 'function') {
+          return nextConfig.webpack(config, options)
+        }
+        return config
+      },
+    })
+  }
+)

--- a/withHmrNextConfig.js
+++ b/withHmrNextConfig.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/commonjs/withHmrNextConfig')

--- a/yarn.lock
+++ b/yarn.lock
@@ -3214,6 +3214,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-fetch@3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4763,6 +4770,18 @@ i18next-fs-backend@^1.0.7:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/i18next-fs-backend/-/i18next-fs-backend-1.1.1.tgz#1d8028926803f63784ffa0f2b1478fb369f92735"
   integrity sha512-RFkfy10hNxJqc7MVAp5iAZq0Tum6msBCNebEe3OelOBvrROvzHUPaR8Qe10RQrOGokTm0W4vJGEJzruFkEt+hQ==
+
+i18next-hmr@^1.7.5:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/i18next-hmr/-/i18next-hmr-1.7.5.tgz#3925f54da18fb67df06fd3bb71c2867da8102347"
+  integrity sha512-V3cFY8xHjtF2X5zI6PHKrEsN7jrh0inUz9Xz2QEoY+7UQ1/LGC6pHrm1JPArBx4Y0JuzMpoCkrC1nFTHxLNleA==
+
+i18next-http-backend@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/i18next-http-backend/-/i18next-http-backend-1.3.0.tgz#fcafb9583cf2942a9c669bd1868ec84a11410536"
+  integrity sha512-49Sf7Dt6GHeFYlCcCTwD39bkaiw7ld8RlGCXw6ZERabN7SXaLM6qRGnd+XbFdPhJHNMHvt/38XiRtJcEgu5Arg==
+  dependencies:
+    cross-fetch "3.1.4"
 
 i18next@^19.7.0:
   version "19.9.2"


### PR DESCRIPTION
Hi. I use this powerful package in my project.

I want to use **hot module reload**, So I find [`i18next-hmr`](https://github.com/felixmosh/i18next-hmr) package to use with `next-i18next`, but `next-i18next` can't catch `i18n` instance to use hmr config.

So, i fork this package to use `i18next-hmr`, and I think have a needs of **hot module reload** at develop.

* I Add `withHmrNextConfig.js` to use `i18next-hmr` webpack plugin and set enable flag and preload i18n namespaces to `next/config`
* At `appWithTranslation`, check the enable flag and apply i18n to `i18next-hmr`
  * When client mode, will set namespaces and use `i18next-http-backend` before create i18n client.

Thank you !
