### PR TITLE
fix: Make appWithTranslation generic over AppProps type

### DIFF
--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -17,11 +17,11 @@ type AppProps = NextJsAppProps & {
 
 export let globalI18n: I18NextClient | null = null
 
-export const appWithTranslation = (
-  WrappedComponent: React.ComponentType<AppProps> | React.ElementType<AppProps>,
+export const appWithTranslation = <Props extends AppProps = AppProps>(
+  WrappedComponent: React.ComponentType<Props> | React.ElementType<AppProps>,
   configOverride: UserConfig | null = null,
 ) => {
-  const AppWithTranslation = (props: AppProps) => {
+  const AppWithTranslation = (props: Props) => {
     const { _nextI18Next } = props.pageProps
     const { locale } = props.router
 

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -18,7 +18,7 @@ type AppProps = NextJsAppProps & {
 export let globalI18n: I18NextClient | null = null
 
 export const appWithTranslation = <Props extends AppProps = AppProps>(
-  WrappedComponent: React.ComponentType<Props> | React.ElementType<AppProps>,
+  WrappedComponent: React.ComponentType<Props>,
   configOverride: UserConfig | null = null,
 ) => {
   const AppWithTranslation = (props: Props) => {


### PR DESCRIPTION
Add support for proper custom App component types
fix #1348 