### PR TITLE
refactor: Set config.react.useSuspense to false

### DIFF
--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -45,6 +45,7 @@ describe('createConfig', () => {
         expect(config.preload).toEqual(['en'])
         expect(config.strictMode).toEqual(true)
         expect(config.use).toEqual([])
+        expect(config.react?.useSuspense).toEqual(false)
 
         expect(fs.existsSync).toHaveBeenCalledTimes(1)
         expect(fs.readdirSync).toHaveBeenCalledTimes(1)
@@ -197,6 +198,7 @@ describe('createConfig', () => {
       expect(config.preload).toBeUndefined()
       expect(config.strictMode).toEqual(true)
       expect(config.use).toEqual([])
+      expect(config.react?.useSuspense).toEqual(false)
     })
 
     it('deep merges backend', () => {

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -25,7 +25,7 @@ export const defaultConfig = {
   localePath: LOCALE_PATH,
   localeStructure: LOCALE_STRUCTURE,
   react: {
-    useSuspense: true,
+    useSuspense: false,
   },
   reloadOnPrerender: false,
   serializeConfig: true,


### PR DESCRIPTION
Fixes #1255

cc @adrai – following up on your comment: https://github.com/isaachinman/next-i18next/issues/1255#issuecomment-864523329

We are already awaiting the initialisation promise inside `serverSideTranslations` [here](https://github.com/isaachinman/next-i18next/blob/e97bfbf4bfb3d3c8660a53018e40cf6e0cfd6865/src/serverSideTranslations.ts#L77).

The reason you have to manually list your namespaces in your demo project [here](https://github.com/locize/next-i18next-locize/blob/main/next-i18next.config.js#L17) is because they are not present in your filesystem, which we normally [query for automatically](https://github.com/isaachinman/next-i18next/blob/e97bfbf4bfb3d3c8660a53018e40cf6e0cfd6865/src/config/createConfig.ts#L120).

Let me know if you think this looks like a safe change 👍 