### PR TITLE
chore: added note for vercel/netlify using serverSideTranslations

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ To migrate from previous versions to the version 8, check out the [v8-migration 
 
 ## Notes
 
+### Vercel and Netlify
+
+These services are not able to directly locate the path of your translations and requires additional configuration. If you are facing issues using `serverSideTranslations` then setting `config.localePath` to use `path.resolve` should resolve this. An example can be [found here](https://github.com/isaachinman/next-i18next/issues/1552#issuecomment-981156476).
+
+
 ### Docker
 
 For Docker deployment, note that if you use the `Dockerfile` from [Next.js docs](https://nextjs.org/docs/deployment#docker-image) do not forget to copy `next.config.js` and `next-i18next.config.js` into the Docker image.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ To migrate from previous versions to the version 8, check out the [v8-migration 
 
 ### Vercel and Netlify
 
-These services are not able to directly locate the path of your translations and requires additional configuration. If you are facing issues using `serverSideTranslations` then setting `config.localePath` to use `path.resolve` should resolve this. An example can be [found here](https://github.com/isaachinman/next-i18next/issues/1552#issuecomment-981156476).
+Some serverless PaaS may not be able to locate the path of your translations and require additional configuration. If you have filesystem issues using `serverSideTranslations`, set `config.localePath` to use `path.resolve`. An example can be [found here](https://github.com/isaachinman/next-i18next/issues/1552#issuecomment-981156476).
 
 
 ### Docker


### PR DESCRIPTION
Added a small note that might help resolve the communication for people deploying on Netlify / Vercel with `serverSideTranslations`. This issue seems to be brought up quite often so adding a note might help mitigate a small portion of those who do use the README.md