### PR TITLE
Allow function type for localePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,16 +223,18 @@ This option will reload your translations whenever `serverSideTranslations` is c
 
 #### Options
 
-| Key                 | Default value        |
-| ------------------- | -------------------- |
-| `defaultNS`         | `'common'`           |
-| `localeExtension`   | `'json'`             |
-| `localePath`        | `'./public/locales'` |
-| `localeStructure`   | `'{{lng}}/{{ns}}'`   |
-| `reloadOnPrerender` | `false`              |
-| `serializeConfig`   | `true`               |
-| `strictMode`        | `true`               |
-| `use` (for plugins) | `[]`                 |
+| Key                 | Default value        | Note                                   |
+| ------------------- | -------------------- | -------------------------------------- |
+| `defaultNS`         | `'common'`           |                                        |
+| `localePath`        | `'./public/locales'` | Can be a function, see note below.     |
+| `localeExtension`   | `'json'`             | Ignored if `localePath` is a function. |
+| `localeStructure`   | `'{{lng}}/{{ns}}'`   | Ignored if `localePath` is a function. |
+| `reloadOnPrerender` | `false`              |                                        |
+| `serializeConfig`   | `true`               |                                        |
+| `strictMode`        | `true`               |                                        |
+| `use` (for plugins) | `[]`                 |                                        |
+
+`localePath` as a function is of the form `(locale: string, namespace: string, env: 'client' | 'server', missing: boolean) => string` returning the entire path including filename and extension. When `missing` is true, return the path for the `addPath` option of `i18next-fs-backend`, when false, return the path for the `loadPath` option. [More info at the `i18next-fs-backend` repo.](https://github.com/i18next/i18next-fs-backend/tree/master#backend-options)
 
 All other [i18next options](https://www.i18next.com/overview/configuration-options) can be passed in as well.
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ This tells `next-i18next` what your `defaultLocale` and other locales are, so th
 ```js
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'de'],
+    defaultLocale: "en",
+    locales: ["en", "de"],
   },
 };
 ```
@@ -85,7 +85,7 @@ Now, create or modify your `next.config.js` file, by passing the `i18n` object i
 #### [`next.config.js`](https://nextjs.org/docs/api-reference/next.config.js/introduction)
 
 ```js
-const { i18n } = require('./next-i18next.config');
+const { i18n } = require("./next-i18next.config");
 
 module.exports = {
   i18n,
@@ -99,7 +99,7 @@ There are three functions that `next-i18next` exports, which you will need to us
 This is a HOC which wraps your [`_app`](https://nextjs.org/docs/advanced-features/custom-app):
 
 ```tsx
-import { appWithTranslation } from 'next-i18next';
+import { appWithTranslation } from "next-i18next";
 
 const MyApp = ({ Component, pageProps }) => <Component {...pageProps} />;
 
@@ -113,12 +113,12 @@ The `appWithTranslation` HOC is primarily responsible for adding a [`I18nextProv
 This is an async function that you need to include on your page-level components, via either [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation) or [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) (depending on your use case):
 
 ```tsx
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 export async function getStaticProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['common', 'footer'])),
+      ...(await serverSideTranslations(locale, ["common", "footer"])),
       // Will be passed to the page component as props
     },
   };
@@ -136,14 +136,14 @@ The `serverSideTranslations` HOC is primarily responsible for passing translatio
 This is the hook which you'll actually use to do the translation itself. The `useTranslation` hook [comes from `react-i18next`](https://react.i18next.com/latest/usetranslation-hook), but can be imported from `next-i18next` directly:
 
 ```tsx
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from "next-i18next";
 
 export const Footer = () => {
-  const { t } = useTranslation('footer');
+  const { t } = useTranslation("footer");
 
   return (
     <footer>
-      <p>{t('description')}</p>
+      <p>{t("description")}</p>
     </footer>
   );
 };
@@ -153,7 +153,7 @@ export const Footer = () => {
 
 By default, `next-i18next` will send _all your namespaces_ down to the client on each initial request. This can be an appropriate approach for smaller apps with less content, but a lot of apps will benefit from splitting namespaces based on route.
 
-To do that, you can pass an array of required namespaces for each page into `serverSideTranslations`. You can see this approach in [examples/simple/pages/index.js](./examples/simple/pages/index.js). Passing in an empty array of required namespaces will send no namespaces. 
+To do that, you can pass an array of required namespaces for each page into `serverSideTranslations`. You can see this approach in [examples/simple/pages/index.js](./examples/simple/pages/index.js). Passing in an empty array of required namespaces will send no namespaces.
 
 Note: `useTranslation` provides namespaces to the component that you use it in. However, `serverSideTranslations` provides the total available namespaces to the entire React tree and belongs on the page level. Both are required.
 
@@ -164,14 +164,14 @@ Note: `useTranslation` provides namespaces to the component that you use it in. 
 If you need to modify more advanced configuration options, you can pass them via `next-i18next.config.js`. For example:
 
 ```js
-const path = require('path');
+const path = require("path");
 
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'de'],
+    defaultLocale: "en",
+    locales: ["en", "de"],
   },
-  localePath: path.resolve('./my/custom/path'),
+  localePath: path.resolve("./my/custom/path"),
 };
 ```
 
@@ -189,8 +189,8 @@ Reason: `function` cannot be serialized as JSON. Please only return JSON seriali
 To fix this, you'll need to set `config.serializeConfig` to `false`, and manually pass your config into `appWithTranslation`:
 
 ```tsx
-import { appWithTranslation } from 'next-i18next';
-import nextI18NextConfig from '../next-i18next.config.js';
+import { appWithTranslation } from "next-i18next";
+import nextI18NextConfig from "../next-i18next.config.js";
 
 const MyApp = ({ Component, pageProps }) => <Component {...pageProps} />;
 
@@ -198,15 +198,15 @@ export default appWithTranslation(MyApp, nextI18NextConfig);
 ```
 
 ```tsx
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import nextI18NextConfig from '../next-i18next.config.js';
+import nextI18NextConfig from "../next-i18next.config.js";
 
 export const getStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(
       locale,
-      ['common', 'footer'],
+      ["common", "footer"],
       nextI18NextConfig
     )),
   },
@@ -234,7 +234,7 @@ This option will reload your translations whenever `serverSideTranslations` is c
 | `strictMode`        | `true`               |                                        |
 | `use` (for plugins) | `[]`                 |                                        |
 
-`localePath` as a function is of the form `(locale: string, namespace: string, env: 'client' | 'server', missing: boolean) => string` returning the entire path including filename and extension. When `missing` is true, return the path for the `addPath` option of `i18next-fs-backend`, when false, return the path for the `loadPath` option. [More info at the `i18next-fs-backend` repo.](https://github.com/i18next/i18next-fs-backend/tree/master#backend-options)
+`localePath` as a function is of the form `(locale: string, namespace: string, missing: boolean) => string` returning the entire path including filename and extension. When `missing` is true, return the path for the `addPath` option of `i18next-fs-backend`, when false, return the path for the `loadPath` option. [More info at the `i18next-fs-backend` repo.](https://github.com/i18next/i18next-fs-backend/tree/master#backend-options)
 
 All other [i18next options](https://www.i18next.com/overview/configuration-options) can be passed in as well.
 
@@ -245,15 +245,15 @@ In some use cases, you might want to load a translation file dynamically without
 This can easily be done by using [addResourceBundle](https://www.i18next.com/how-to/add-or-load-translations#add-after-init):
 
 ```tsx
-import { i18n } from 'next-i18next'
+import { i18n } from "next-i18next";
 
 const Component = () => {
-  const { locale } = useRouter()
+  const { locale } = useRouter();
 
   useEffect(() => {
-    i18n.addResourceBundle(locale, '<namespace name>')
-  }, [])
-}
+    i18n.addResourceBundle(locale, "<namespace name>");
+  }, []);
+};
 ```
 
 ## Migration to v8
@@ -265,7 +265,6 @@ To migrate from previous versions to the version 8, check out the [v8-migration 
 ### Vercel and Netlify
 
 Some serverless PaaS may not be able to locate the path of your translations and require additional configuration. If you have filesystem issues using `serverSideTranslations`, set `config.localePath` to use `path.resolve`. An example can be [found here](https://github.com/isaachinman/next-i18next/issues/1552#issuecomment-981156476).
-
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ This tells `next-i18next` what your `defaultLocale` and other locales are, so th
 ```js
 module.exports = {
   i18n: {
-    defaultLocale: "en",
-    locales: ["en", "de"],
+    defaultLocale: 'en',
+    locales: ['en', 'de'],
   },
 };
 ```
@@ -85,7 +85,7 @@ Now, create or modify your `next.config.js` file, by passing the `i18n` object i
 #### [`next.config.js`](https://nextjs.org/docs/api-reference/next.config.js/introduction)
 
 ```js
-const { i18n } = require("./next-i18next.config");
+const { i18n } = require('./next-i18next.config');
 
 module.exports = {
   i18n,
@@ -99,7 +99,7 @@ There are three functions that `next-i18next` exports, which you will need to us
 This is a HOC which wraps your [`_app`](https://nextjs.org/docs/advanced-features/custom-app):
 
 ```tsx
-import { appWithTranslation } from "next-i18next";
+import { appWithTranslation } from 'next-i18next';
 
 const MyApp = ({ Component, pageProps }) => <Component {...pageProps} />;
 
@@ -113,12 +113,12 @@ The `appWithTranslation` HOC is primarily responsible for adding a [`I18nextProv
 This is an async function that you need to include on your page-level components, via either [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation) or [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) (depending on your use case):
 
 ```tsx
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
 export async function getStaticProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ["common", "footer"])),
+      ...(await serverSideTranslations(locale, ['common', 'footer'])),
       // Will be passed to the page component as props
     },
   };
@@ -136,14 +136,14 @@ The `serverSideTranslations` HOC is primarily responsible for passing translatio
 This is the hook which you'll actually use to do the translation itself. The `useTranslation` hook [comes from `react-i18next`](https://react.i18next.com/latest/usetranslation-hook), but can be imported from `next-i18next` directly:
 
 ```tsx
-import { useTranslation } from "next-i18next";
+import { useTranslation } from 'next-i18next';
 
 export const Footer = () => {
-  const { t } = useTranslation("footer");
+  const { t } = useTranslation('footer');
 
   return (
     <footer>
-      <p>{t("description")}</p>
+      <p>{t('description')}</p>
     </footer>
   );
 };
@@ -153,7 +153,7 @@ export const Footer = () => {
 
 By default, `next-i18next` will send _all your namespaces_ down to the client on each initial request. This can be an appropriate approach for smaller apps with less content, but a lot of apps will benefit from splitting namespaces based on route.
 
-To do that, you can pass an array of required namespaces for each page into `serverSideTranslations`. You can see this approach in [examples/simple/pages/index.js](./examples/simple/pages/index.js). Passing in an empty array of required namespaces will send no namespaces.
+To do that, you can pass an array of required namespaces for each page into `serverSideTranslations`. You can see this approach in [examples/simple/pages/index.js](./examples/simple/pages/index.js). Passing in an empty array of required namespaces will send no namespaces. 
 
 Note: `useTranslation` provides namespaces to the component that you use it in. However, `serverSideTranslations` provides the total available namespaces to the entire React tree and belongs on the page level. Both are required.
 
@@ -164,14 +164,14 @@ Note: `useTranslation` provides namespaces to the component that you use it in. 
 If you need to modify more advanced configuration options, you can pass them via `next-i18next.config.js`. For example:
 
 ```js
-const path = require("path");
+const path = require('path');
 
 module.exports = {
   i18n: {
-    defaultLocale: "en",
-    locales: ["en", "de"],
+    defaultLocale: 'en',
+    locales: ['en', 'de'],
   },
-  localePath: path.resolve("./my/custom/path"),
+  localePath: path.resolve('./my/custom/path'),
 };
 ```
 
@@ -189,8 +189,8 @@ Reason: `function` cannot be serialized as JSON. Please only return JSON seriali
 To fix this, you'll need to set `config.serializeConfig` to `false`, and manually pass your config into `appWithTranslation`:
 
 ```tsx
-import { appWithTranslation } from "next-i18next";
-import nextI18NextConfig from "../next-i18next.config.js";
+import { appWithTranslation } from 'next-i18next';
+import nextI18NextConfig from '../next-i18next.config.js';
 
 const MyApp = ({ Component, pageProps }) => <Component {...pageProps} />;
 
@@ -198,15 +198,15 @@ export default appWithTranslation(MyApp, nextI18NextConfig);
 ```
 
 ```tsx
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
-import nextI18NextConfig from "../next-i18next.config.js";
+import nextI18NextConfig from '../next-i18next.config.js';
 
 export const getStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(
       locale,
-      ["common", "footer"],
+      ['common', 'footer'],
       nextI18NextConfig
     )),
   },
@@ -245,15 +245,15 @@ In some use cases, you might want to load a translation file dynamically without
 This can easily be done by using [addResourceBundle](https://www.i18next.com/how-to/add-or-load-translations#add-after-init):
 
 ```tsx
-import { i18n } from "next-i18next";
+import { i18n } from 'next-i18next'
 
 const Component = () => {
-  const { locale } = useRouter();
+  const { locale } = useRouter()
 
   useEffect(() => {
-    i18n.addResourceBundle(locale, "<namespace name>");
-  }, []);
-};
+    i18n.addResourceBundle(locale, '<namespace name>')
+  }, [])
+}
 ```
 
 ## Migration to v8
@@ -265,6 +265,7 @@ To migrate from previous versions to the version 8, check out the [v8-migration 
 ### Vercel and Netlify
 
 Some serverless PaaS may not be able to locate the path of your translations and require additional configuration. If you have filesystem issues using `serverSideTranslations`, set `config.localePath` to use `path.resolve`. An example can be [found here](https://github.com/isaachinman/next-i18next/issues/1552#issuecomment-981156476).
+
 
 ### Docker
 

--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -170,6 +170,36 @@ describe('createConfig', () => {
         expect(fs.readdirSync).toHaveBeenCalledTimes(0)
       })
     })
+
+    describe('with a function for localePath', () => {
+      const localePathFn: UserConfig['localePath'] = (locale, namespace, env, missing) => `${missing}/${env}/${namespace}/${locale}.json`
+
+      it('returns a config whose localePath works as expected', () => {
+        const config = createConfig({
+          i18n: {
+            defaultLocale: 'en',
+            locales: ['en'],
+          },
+          lng: 'en',
+          localePath: localePathFn,
+          ns: ['common'],
+        })
+
+        expect(((config.backend as any).loadPath)('en', 'common')).toBe('false/server/common/en.json')
+        expect(((config.backend as any).addPath)('en', 'common')).toBe('true/server/common/en.json')
+      })
+
+      it('throws an error if namespaces are not provided', () => {
+        expect(() => createConfig({
+          i18n: {
+            defaultLocale: 'en',
+            locales: ['en'],
+          },
+          lng: 'en',
+          localePath: localePathFn,
+        })).toThrow('Must provide all namespaces in ns option if using a function as localePath')
+      })
+    })
   })
 
   describe('client side', () => {
@@ -242,6 +272,25 @@ describe('createConfig', () => {
             type: 'backend',
           }] } as UserConfig)
         expect((config.backend as any)).toEqual({ hello: 'world' })
+      })
+    })
+
+    describe('with a function for localePath', () => {
+      const localePathFn: UserConfig['localePath'] = (locale, namespace, env, missing) => `${missing}/${env}/${namespace}/${locale}.json`
+
+      it('returns a config whose localePath works as expected', () => {
+        const config = createConfig({
+          i18n: {
+            defaultLocale: 'en',
+            locales: ['en'],
+          },
+          lng: 'en',
+          localePath: localePathFn,
+          ns: ['common'],
+        })
+
+        expect(((config.backend as any).loadPath)('en', 'common')).toBe('false/client/common/en.json')
+        expect(((config.backend as any).addPath)('en', 'common')).toBe('true/client/common/en.json')
       })
     })
   })

--- a/src/config/createConfig.test.ts
+++ b/src/config/createConfig.test.ts
@@ -172,9 +172,10 @@ describe('createConfig', () => {
     })
 
     describe('with a function for localePath', () => {
-      const localePathFn: UserConfig['localePath'] = (locale, namespace, env, missing) => `${missing}/${env}/${namespace}/${locale}.json`
+      const localePathFn: UserConfig['localePath'] = (locale, namespace, missing) => `${missing}/${namespace}/${locale}.json`
 
       it('returns a config whose localePath works as expected', () => {
+        (fs.existsSync as jest.Mock).mockReturnValueOnce(true)
         const config = createConfig({
           i18n: {
             defaultLocale: 'en',
@@ -185,11 +186,23 @@ describe('createConfig', () => {
           ns: ['common'],
         })
 
-        expect(((config.backend as any).loadPath)('en', 'common')).toBe('false/server/common/en.json')
-        expect(((config.backend as any).addPath)('en', 'common')).toBe('true/server/common/en.json')
+        expect(((config.backend as any).loadPath)('en', 'common')).toBe('false/common/en.json')
+        expect(((config.backend as any).addPath)('en', 'common')).toBe('true/common/en.json')
+      })
+
+      it('when filesystem is missing defaultNS throws an error', () => {
+        (fs.existsSync as jest.Mock).mockReturnValueOnce(false)
+
+        const config = createConfig.bind(null, {
+          lng: 'en',
+          localePath: localePathFn,
+        } as UserConfig)
+
+        expect(config).toThrow('Default namespace not found at false/common/en.json')
       })
 
       it('throws an error if namespaces are not provided', () => {
+        (fs.existsSync as jest.Mock).mockReturnValueOnce(true)
         expect(() => createConfig({
           i18n: {
             defaultLocale: 'en',
@@ -276,7 +289,7 @@ describe('createConfig', () => {
     })
 
     describe('with a function for localePath', () => {
-      const localePathFn: UserConfig['localePath'] = (locale, namespace, env, missing) => `${missing}/${env}/${namespace}/${locale}.json`
+      const localePathFn: UserConfig['localePath'] = (locale, namespace, missing) => `${missing}/${namespace}/${locale}.json`
 
       it('returns a config whose localePath works as expected', () => {
         const config = createConfig({
@@ -289,8 +302,8 @@ describe('createConfig', () => {
           ns: ['common'],
         })
 
-        expect(((config.backend as any).loadPath)('en', 'common')).toBe('false/client/common/en.json')
-        expect(((config.backend as any).addPath)('en', 'common')).toBe('true/client/common/en.json')
+        expect(((config.backend as any).loadPath)('en', 'common')).toBe('false/common/en.json')
+        expect(((config.backend as any).addPath)('en', 'common')).toBe('true/common/en.json')
       })
     })
   })

--- a/src/serverSideTranslations.test.tsx
+++ b/src/serverSideTranslations.test.tsx
@@ -231,4 +231,18 @@ describe('serverSideTranslations', () => {
 
     expect(globalI18n?.reloadResources).toHaveBeenCalledTimes(0)
   })
+
+  it('throws if a function is used for localePath and namespaces are not provided', async () => {
+    const localePathFn: UserConfig['localePath'] = (locale, namespace, env, missing) => `${missing}/${env}/${namespace}/${locale}.json`
+    const config: UserConfig = {
+      i18n: {
+        defaultLocale: 'en',
+        locales: ['en'],
+      },
+      localePath: localePathFn,
+      ns: ['common'],
+    }
+    await expect(serverSideTranslations('en-US', undefined, config))
+      .rejects.toMatchObject({ message: 'Must provide namespacesRequired to serverSideTranslations when using a function as localePath' })
+  })
 })

--- a/src/serverSideTranslations.test.tsx
+++ b/src/serverSideTranslations.test.tsx
@@ -233,7 +233,7 @@ describe('serverSideTranslations', () => {
   })
 
   it('throws if a function is used for localePath and namespaces are not provided', async () => {
-    const localePathFn: UserConfig['localePath'] = (locale, namespace, env, missing) => `${missing}/${env}/${namespace}/${locale}.json`
+    const localePathFn: UserConfig['localePath'] = (locale, namespace, missing) => `${missing}/${namespace}/${locale}.json`
     const config: UserConfig = {
       i18n: {
         defaultLocale: 'en',

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -85,6 +85,9 @@ export const serverSideTranslations = async (
   })
 
   if (!Array.isArray(namespacesRequired)) {
+    if (typeof localePath === 'function')
+      throw new Error('Must provide namespacesRequired to serverSideTranslations when using a function as localePath')
+
     const getLocaleNamespaces = (path: string) =>
       fs.readdirSync(path)
         .map(file => file.replace(`.${localeExtension}`, ''))

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -85,8 +85,9 @@ export const serverSideTranslations = async (
   })
 
   if (!Array.isArray(namespacesRequired)) {
-    if (typeof localePath === 'function')
+    if (typeof localePath === 'function') {
       throw new Error('Must provide namespacesRequired to serverSideTranslations when using a function as localePath')
+    }
 
     const getLocaleNamespaces = (path: string) =>
       fs.readdirSync(path)

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type UserConfig = {
   i18n: NextJsI18NConfig
   localeExtension?: string
   localePath?:
-    string | ((locale: string, namespace: string, env: 'client' | 'server', missing: boolean) => string)
+    string | ((locale: string, namespace: string, missing: boolean) => string)
   localeStructure?: string
   reloadOnPrerender?: boolean
   serializeConfig?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,8 @@ type NextJsI18NConfig = {
 export type UserConfig = {
   i18n: NextJsI18NConfig
   localeExtension?: string
-  localePath?: string
+  localePath?:
+    string | ((locale: string, namespace: string, env: 'client' | 'server', missing: boolean) => string)
   localeStructure?: string
   reloadOnPrerender?: boolean
   serializeConfig?: boolean


### PR DESCRIPTION
Fixes #1500

> `localePath` as a function is of the form `(locale: string, namespace: string, env: 'client' | 'server', missing: boolean) => string` returning the entire path including filename and extension. When `missing` is true, return the path for the `addPath` option of `i18next-fs-backend`, when false, return the path for the `loadPath` option. [More info at the `i18next-fs-backend` repo.](https://github.com/i18next/i18next-fs-backend/tree/master#backend-options)

See comments

Tests added ~~Wasn't sure how to add tests for the additional functionality - any guidance appreciated (maybe I should add tests for the error cases and that the function is correctly in the final config by calling it?)~~