### PR TITLE
feat: Expose Translation react-i18next component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-export { I18nContext, Trans, useTranslation, withTranslation } from 'react-i18next'
+export { I18nContext, Trans, Translation, useTranslation, withTranslation } from 'react-i18next'
 
 export { appWithTranslation, globalI18n as i18n } from './appWithTranslation'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ import {
   WithTranslation as ReactI18nextWithTranslation,
   Resources,
   DefaultNamespace,
+  Translation,
 } from 'react-i18next'
 import { InitOptions, i18n as I18NextClient, TFunction as I18NextTFunction } from 'i18next'
 import { appWithTranslation, i18n } from './'
@@ -63,6 +64,7 @@ export {
   appWithTranslation,
   useTranslation,
   Trans,
+  Translation,
   withTranslation,
   Resources,
   DefaultNamespace,


### PR DESCRIPTION
These changes export the [react-i18next Translation component](https://react.i18next.com/latest/translation-render-prop) from the next-i18next module. I found this component the best match for introducing translations in the [Page.getLayout]( https://nextjs.org/docs/basic-features/layouts#per-page-layouts) function. The useTranslation hook is [not allowed because the getLayout function is not top-level](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level).

I also added test coverage for the Translation component by using it on the second page to render the header. It's tested by `yarn test:e2e`.