### PR TITLE
fix: appWithTranslation useMemo bug (null locale)

### DIFF
--- a/src/appWithTranslation.client.test.tsx
+++ b/src/appWithTranslation.client.test.tsx
@@ -167,4 +167,20 @@ describe('appWithTranslation', () => {
     )
     expect(createClient).toHaveBeenCalledTimes(3)
   })
+
+  it('assures locale key is set to the right value', () => {
+    const { rerender } = renderComponent()
+    const Dummy = (
+      <DummyApp
+        {...defaultRenderProps}
+      />
+    )
+    rerender(Dummy)
+    rerender(Dummy)
+
+    const [args] = (I18nextProvider as jest.Mock).mock.calls
+
+    expect(args[0].children.key).toBe('en')
+  })
+
 })

--- a/src/appWithTranslation.client.test.tsx
+++ b/src/appWithTranslation.client.test.tsx
@@ -169,18 +169,18 @@ describe('appWithTranslation', () => {
   })
 
   it('assures locale key is set to the right value', () => {
-    const { rerender } = renderComponent()
-    const Dummy = (
-      <DummyApp
-        {...defaultRenderProps}
-      />
-    )
-    rerender(Dummy)
-    rerender(Dummy)
+    const { rerender } = render(<DummyApp
+      {...(createProps('de'))}
+    />)
+    rerender(<DummyApp
+      {...(createProps('en'))}
+    />)
+    rerender(<DummyApp
+      {...(createProps('en'))}
+    />)
 
     const [args] = (I18nextProvider as jest.Mock).mock.calls
 
     expect(args[0].children.key).toBe('en')
   })
-
 })

--- a/src/appWithTranslation.client.test.tsx
+++ b/src/appWithTranslation.client.test.tsx
@@ -169,18 +169,39 @@ describe('appWithTranslation', () => {
   })
 
   it('assures locale key is set to the right value', () => {
+    const props = createProps('de')
+
     const { rerender } = render(<DummyApp
+      {...props}
+    />)
+
+    props.router.locale = 'en'
+    props.pageProps._nextI18Next.initialLocale = 'en'
+
+    rerender(<DummyApp
+      {...props}
+    />)
+    rerender(<DummyApp
+      {...props}
+    />)
+    rerender(<DummyApp
+      {...props}
+    />)
+
+    props.router.locale = 'de'
+    props.pageProps._nextI18Next.initialLocale = 'de'
+
+    rerender(<DummyApp
       {...(createProps('de'))}
     />)
-    rerender(<DummyApp
-      {...(createProps('en'))}
-    />)
-    rerender(<DummyApp
-      {...(createProps('en'))}
-    />)
 
-    const [args] = (I18nextProvider as jest.Mock).mock.calls
+    const [[first], [second], [third], [fourth], [fifth]] =
+      (I18nextProvider as jest.Mock).mock.calls
 
-    expect(args[0].children.key).toBe('en')
+    expect(first.children.key).toEqual('de')
+    expect(second.children.key).toEqual('en')
+    expect(third.children.key).toEqual('en')
+    expect(fourth.children.key).toEqual('en')
+    expect(fifth.children.key).toEqual('de')
   })
 })

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import { I18nextProvider } from 'react-i18next'
 import type { AppProps as NextJsAppProps } from 'next/app'
@@ -21,10 +21,9 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
   WrappedComponent: React.ComponentType<Props>,
   configOverride: UserConfig | null = null,
 ) => {
-  let locale: string | null = null
-
   const AppWithTranslation = (props: Props) => {
     const { _nextI18Next } = props.pageProps as SSRConfig
+    const [locale, setLocale] = useState<string | undefined>(undefined)
 
     // Memoize the instance and only re-initialize when either:
     // 1. The route changes (non-shallowly)
@@ -35,7 +34,7 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
       let { userConfig } = _nextI18Next
       const { initialI18nStore, initialLocale } = _nextI18Next
 
-      locale = initialLocale
+      setLocale(initialLocale)
 
       if (userConfig === null && configOverride === null) {
         throw new Error('appWithTranslation was called without a next-i18next config')
@@ -52,9 +51,9 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
       const instance = createClient({
         ...createConfig({
           ...userConfig,
-          lng: locale,
+          lng: locale || initialLocale,
         }),
-        lng: locale,
+        lng: locale || initialLocale,
         resources: initialI18nStore,
       }).i18n
 

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -23,7 +23,7 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
 ) => {
   const AppWithTranslation = (props: Props) => {
     const { _nextI18Next } = props.pageProps as SSRConfig
-    const [locale, setLocale] = useState<string | undefined>(_nextI18Next ? _nextI18Next.initialLocale : undefined) // eslint-disable-line
+    const [locale, setLocale] = useState<string>(_nextI18Next?.initialLocale)
 
     // Memoize the instance and only re-initialize when either:
     // 1. The route changes (non-shallowly)

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import { I18nextProvider } from 'react-i18next'
 import type { AppProps as NextJsAppProps } from 'next/app'
@@ -23,7 +23,7 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
 ) => {
   const AppWithTranslation = (props: Props) => {
     const { _nextI18Next } = props.pageProps as SSRConfig
-    const [locale, setLocale] = useState<string>(_nextI18Next?.initialLocale)
+    const locale: string | null = _nextI18Next?.initialLocale ?? null
 
     // Memoize the instance and only re-initialize when either:
     // 1. The route changes (non-shallowly)
@@ -32,12 +32,7 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
       if (!_nextI18Next) return null
 
       let { userConfig } = _nextI18Next
-      const { initialI18nStore, initialLocale } = _nextI18Next
-
-      // If initialLocale has changed, change the locale state to the new value.
-      if (initialLocale && (!locale || (locale != initialLocale))) {
-        setLocale(initialLocale)
-      }
+      const { initialI18nStore } = _nextI18Next
 
       if (userConfig === null && configOverride === null) {
         throw new Error('appWithTranslation was called without a next-i18next config')
@@ -51,14 +46,12 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
         throw new Error('appWithTranslation was called without config.i18n')
       }
 
-      const lng = locale || initialLocale
-
       const instance = createClient({
         ...createConfig({
           ...userConfig,
-          lng,
+          lng: locale,
         }),
-        lng,
+        lng: locale,
         resources: initialI18nStore,
       }).i18n
 

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -23,7 +23,7 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
 ) => {
   const AppWithTranslation = (props: Props) => {
     const { _nextI18Next } = props.pageProps as SSRConfig
-    const [locale, setLocale] = useState<string | undefined>(undefined)
+    const [locale, setLocale] = useState<string | undefined>(_nextI18Next ? _nextI18Next.initialLocale : undefined) // eslint-disable-line
 
     // Memoize the instance and only re-initialize when either:
     // 1. The route changes (non-shallowly)
@@ -34,7 +34,10 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
       let { userConfig } = _nextI18Next
       const { initialI18nStore, initialLocale } = _nextI18Next
 
-      setLocale(initialLocale)
+      // If initialLocale has changed, change the locale state to the new value.
+      if (initialLocale && (!locale || (locale != initialLocale))) {
+        setLocale(initialLocale)
+      }
 
       if (userConfig === null && configOverride === null) {
         throw new Error('appWithTranslation was called without a next-i18next config')
@@ -48,12 +51,14 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
         throw new Error('appWithTranslation was called without config.i18n')
       }
 
+      const lng = locale || initialLocale
+
       const instance = createClient({
         ...createConfig({
           ...userConfig,
-          lng: locale || initialLocale,
+          lng,
         }),
-        lng: locale || initialLocale,
+        lng,
         resources: initialI18nStore,
       }).i18n
 

--- a/src/appWithTranslation.tsx
+++ b/src/appWithTranslation.tsx
@@ -21,9 +21,10 @@ export const appWithTranslation = <Props extends AppProps = AppProps>(
   WrappedComponent: React.ComponentType<Props>,
   configOverride: UserConfig | null = null,
 ) => {
+  let locale: string | null = null
+
   const AppWithTranslation = (props: Props) => {
     const { _nextI18Next } = props.pageProps as SSRConfig
-    let locale = null
 
     // Memoize the instance and only re-initialize when either:
     // 1. The route changes (non-shallowly)


### PR DESCRIPTION
This PR will fix the Next/Link app unmount.

I placed the locale in a state instead of a variable, which fixes locale getting set to null.

The state will only change if the `initialLocale` has changed and is not equal to the current state and is not null.

Fixes #1628 