### PR TITLE
chore: Mute vercel bot

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
Every merged PR in this repo triggers an extra GitHub notification. This happens because Vercel bot comments on the merge commit:

<img width="918" alt="Screenshot 2022-02-08 at 19 59 09" src="https://user-images.githubusercontent.com/608862/153068754-4d19e3e0-4354-4e37-a791-9aef1461834d.png">

This PR silences Vercel bot, so it will no longer leave comments. Release previews are still accessible for PRs:

<img width="862" alt="Screenshot 2022-02-08 at 20 21 06" src="https://user-images.githubusercontent.com/608862/153069237-286b2f38-8950-4566-a323-fd55cf7218f6.png">

We are using this setup in [blockprotocol/blockprotocol](https://github.com/blockprotocol/blockprotocol) and it reduces notification spam quite substantially! 🙂

Docs: https://vercel.com/support/articles/how-to-prevent-vercel-github-comments

Feel free yo close this PR if you see downsides in the idea.