### PR TITLE
docs: Clarify config for custom interpolation suffix/prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,27 @@ const Component = () => {
 }
 ```
 
+#### Custom interpolation prefix/suffix
+
+By default, i18next uses `{{` as prefix and `}}` as suffix for [interpolation](https://www.i18next.com/translation-function/interpolation).
+If you want/need to override these interpolation settings, you **must** also specify an alternative `localeStructure` setting that matches your custom prefix and suffix.
+
+For example, if you want to use `{` and `}` the config would look like this:
+
+```js
+{
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'nl'],
+  },
+  interpolation: {
+    prefix: '{',
+    suffix: '}',
+  },
+  localeStructure: '{lng}/{ns}',
+}
+```
+
 ## Migration to v8
 
 To migrate from previous versions to the version 8, check out the [v8-migration guide](https://github.com/isaachinman/next-i18next/tree/master/docs/v8-migration.md)


### PR DESCRIPTION
It took me a while to figure out how to get a custom interpolation prefix/suffix to work.

I think it's a little unintuitive that changing an option that relates to how the text inside the translation files is structured has a knock-on effect to how files are loaded. That is not criticism, I realize it's because of how the various packages interact, but it's still a bit of a head-scratcher.

After doing some digging, I came across #1090 that clarifies the issue, but I feel it's worth putting this in the README.

This PR does that. It's not much, but I hope you find it useful.