### PR TITLE
feat: Link to react-i18next config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ export const Footer = () => {
 
 By default, `next-i18next` will send _all your namespaces_ down to the client on each initial request. This can be an appropriate approach for smaller apps with less content, but a lot of apps will benefit from splitting namespaces based on route.
 
-To do that, you can pass an array of required namespaces for each page into `serverSideTranslations`. You can see this approach in [examples/simple/pages/index.js](./examples/simple/pages/index.js). Passing in an empty array of required namespaces will send no namespaces. 
+To do that, you can pass an array of required namespaces for each page into `serverSideTranslations`. You can see this approach in [examples/simple/pages/index.js](./examples/simple/pages/index.js). Passing in an empty array of required namespaces will send no namespaces.
 
 Note: `useTranslation` provides namespaces to the component that you use it in. However, `serverSideTranslations` provides the total available namespaces to the entire React tree and belongs on the page level. Both are required.
 
@@ -236,7 +236,7 @@ This option will reload your translations whenever `serverSideTranslations` is c
 
 `localePath` as a function is of the form `(locale: string, namespace: string, missing: boolean) => string` returning the entire path including filename and extension. When `missing` is true, return the path for the `addPath` option of `i18next-fs-backend`, when false, return the path for the `loadPath` option. [More info at the `i18next-fs-backend` repo.](https://github.com/i18next/i18next-fs-backend/tree/master#backend-options)
 
-All other [i18next options](https://www.i18next.com/overview/configuration-options) can be passed in as well.
+All other [i18next options](https://www.i18next.com/overview/configuration-options) and [react-i18next options](https://react.i18next.com/latest/i18next-instance) can be passed in as well.
 
 #### Loading Namespaces Dynamically Client Side
 


### PR DESCRIPTION
Hi! I just wanted to propose a small update to README.
After a bit of fiddling I realized, `transKeepBasicHtmlNodesFor` is under `react` key so wanted to include the link to the docs from here since i18next docs are separated from the one for react-i18next.
