### PR TITLE
Feature: allow function returning promise to be used in the user config

### DIFF
--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -43,7 +43,9 @@ export const serverSideTranslations = async (
     throw new Error('Initial locale argument was not passed into serverSideTranslations')
   }
 
-  let userConfig = configOverride
+  let userConfig: UserConfig
+    | (() => UserConfig | Promise<UserConfig>)
+    | null = configOverride
 
   if (!userConfig && fs.existsSync(path.resolve(DEFAULT_CONFIG_PATH))) {
     userConfig = await import(path.resolve(DEFAULT_CONFIG_PATH))
@@ -51,6 +53,10 @@ export const serverSideTranslations = async (
 
   if (userConfig === null) {
     throw new Error('next-i18next was unable to find a user config')
+  }
+
+  if (typeof userConfig === 'function') {
+    userConfig = await userConfig()
   }
 
   const config = createConfig({


### PR DESCRIPTION
Thanks to this improvement we can use function returning Promise (or not) in `next-i18next.config.js`.
This is a must-have feature for our monorepo project where we don't know early which locales will be used in the build so I have to use async/await stuff to determine the locales.